### PR TITLE
Add Phase VI.1 operationalization automation and scaffolding

### DIFF
--- a/.github/copilot-tasks/phase_vi1_operationalization.yaml
+++ b/.github/copilot-tasks/phase_vi1_operationalization.yaml
@@ -1,0 +1,387 @@
+task: "Operationalize Phase VI.1 — Φ_QEVF, Observability, QMP, and Phase VII Readiness"
+description: >
+  Convert the Phase VI.1 status specification into executable repo artifacts: closed-loop Φ_QEVF verifier
+  harness with scipy-backed KS test, three-region observability with Thanos retention, ORD archive pipeline
+  with zstd compression and signed manifests, and a Quantum Market Protocol (QMP) sandbox wired to live
+  telemetry proxies. Produce validation reports, Grafana dashboards, CI gates with fault injection, and
+  README updates. Include Phase VII launch scaffolding (e.g., migration hooks).
+
+inputs:
+  spec_file:
+    description: "Path to the Phase VI.1 source text (md/markdown)"
+    required: false
+    default: "docs/phase/VI.1_status.md"
+  regions:
+    description: "Comma-separated regions to model"
+    required: false
+    default: "us-east-1,eu-central-1,ap-southeast-1"
+  canary_percent:
+    description: "Blue/green canary exposure percentage"
+    required: false
+    default: "10"
+  ord_interval_sec:
+    description: "ORD write cadence (seconds)"
+    required: false
+    default: "30"
+  ord_checkpoint_hours:
+    description: "ORD checkpoint period (hours)"
+    required: false
+    default: "6"
+  ks_confidence:
+    description: "Target KS confidence threshold (%)"
+    required: false
+    default: "95"
+  tol_floor_pct:
+    description: "Adaptive tolerance floor (%)"
+    required: false
+    default: "2"
+  retention_days:
+    description: "Prometheus/Thanos retention days"
+    required: false
+    default: "90"
+  qmp_base_price_usd:
+    description: "Base EPH price in USD"
+    required: false
+    default: "0.0004"
+
+env:
+  PHASE_DIR: "docs/phase"
+  OBS_DIR: "infra/observability"
+  VERIF_DIR: "tools/phi_qevf"
+  QMP_DIR: "tools/qmp_sandbox"
+  ORD_DIR: "infra/ord_pipeline"
+  LOG: "logs/phase_vi1_operationalization.log"
+  PYTHON_VERSION: "3.12"
+
+success_criteria:
+  - "Φ_QEVF harness runs on sample traces, emitting RMSE/MAE/variance and KS p-value ≥ target confidence"
+  - "Adaptive tolerance converges with floor respected at configured tol_floor_pct"
+  - "ORD pipeline writes zstd metrics every ord_interval_sec with ord_checkpoint_hours h checkpoints and signed manifests"
+  - "Prometheus+Grafana+Thanos stacks scaffolded with retention_days and regional remotes (list format)"
+  - "QMP sandbox computes EPH pricing streams using live proxy metrics; latency < 60 s (simulated)"
+  - "CI workflow enforces variance < 5%, recall ≥ 95%, false positives < 1% on injected faults"
+  - "README and dashboards updated; artifacts checksummed for audit; Phase VII scaffold present"
+
+steps:
+  - name: Bootstrap folders and log
+    run: |
+      set -euo pipefail
+      mkdir -p "$(dirname "${LOG}")" "${PHASE_DIR}" "${OBS_DIR}" "${VERIF_DIR}" "${QMP_DIR}" "${ORD_DIR}" .github/workflows dashboards scripts out logs
+      echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') Phase VI.1 operationalization start" | tee -a "${LOG}"
+
+  - name: Validate inputs
+    run: |
+      set -euo pipefail
+      [[ -n "${{ inputs.regions }}" ]] || { echo "Error: regions required" >&2; exit 1; }
+      echo "Validated: regions='${{ inputs.regions }}', retention=${{ inputs.retention_days }}d" | tee -a "${LOG}"
+
+  - name: Import Phase VI.1 status text (if not present)
+    run: |
+      set -euo pipefail
+      test -f "${{ inputs.spec_file }}" || cat > "${{ inputs.spec_file }}" <<'MD'
+      # Phase VI.1 Status (placeholder)
+      Provide your status brief here or keep using the in-repo version.
+      MD
+      echo "Spec imported: ${{ inputs.spec_file }}" | tee -a "${LOG}"
+
+  - name: Install common deps (for scaffolding)
+    run: |
+      set -euo pipefail
+      pip install numpy scipy scikit-learn zstandard yq
+
+  - name: Scaffold Φ_QEVF verifier harness
+    run: |
+      set -euo pipefail
+      cat > ${VERIF_DIR}/phi_qevf.py <<'PY'
+      import numpy as np
+      import json
+      import hashlib
+      from pathlib import Path
+      from scipy.stats import ks_2samp
+      import sys
+      def rmse(a, b): a, b = np.array(a), np.array(b); return float(np.sqrt(np.mean((a - b) ** 2)))
+      def mae(a, b): a, b = np.array(a), np.array(b); return float(np.mean(np.abs(a - b)))
+      def variance(a): a = np.array(a); return float(np.var(a))
+      def ks_confidence(a, b, alpha=0.05):
+          # KS p-value to confidence: 100 * (1 - alpha if p >= alpha else 0)
+          stat, p = ks_2samp(a, b); return float(100 * (1 if p >= alpha else 0))
+      def verify(trace, ref, tol_floor=0.02):
+          r = {
+              "rmse": rmse(trace, ref),
+              "mae": mae(trace, ref),
+              "variance_pct": variance(trace) * 100.0,
+              "ks_confidence_pct": ks_confidence(trace, ref)
+          }
+          r["adaptive_tolerance_pct"] = max(tol_floor * 100.0, np.sqrt(r["variance_pct"]))
+          r["pass"] = (r["ks_confidence_pct"] >= 95.0) and (r["variance_pct"] < 5.0)
+          return r
+      def write_signed(path, obj):
+          b = json.dumps(obj, indent=2).encode('utf-8')
+          Path(path).write_bytes(b)
+          sig = hashlib.sha256(b).hexdigest()
+          Path(str(path) + ".sha256").write_text(sig)
+      if __name__ == "__main__":
+          try:
+              n = 10000
+              ref = np.sin(np.linspace(0, 100, n))
+              trace = ref + np.random.normal(0, 0.003, size=n)
+              res = verify(trace, ref, tol_floor=0.02)
+              Path("out").mkdir(exist_ok=True)
+              write_signed("out/phi_qevf_summary.json", res)
+              print(json.dumps(res, indent=2))
+          except Exception as e:
+              print(f"Error: {e}", file=sys.stderr)
+              sys.exit(1)
+      PY
+      python ${VERIF_DIR}/phi_qevf.py | tee -a "${LOG}"
+
+  - name: Scaffold anomaly detection (Isolation Forest + Z-score with metrics)
+    run: |
+      set -euo pipefail
+      cat > ${VERIF_DIR}/anomaly_stack.py <<'PY'
+      import numpy as np
+      import json
+      from sklearn.ensemble import IsolationForest
+      import sys
+      def detect(series, z_thresh=3.5, contamination=0.01):
+          x = np.array(series).reshape(-1, 1)
+          # Inject known anomalies for metric eval
+          clean_x = x.copy()
+          anomaly_indices = [123, 4567]  # Known injections
+          x[anomaly_indices] = [8, -7] if len(x) > 4567 else x[anomaly_indices] + 10
+          true_anoms = np.zeros(len(x), dtype=bool)
+          true_anoms[anomaly_indices[:len(x)]] = True
+          iforest = IsolationForest(n_estimators=100, contamination=contamination, random_state=42).fit(x)
+          iso_flags = (iforest.predict(x) == -1)
+          z_flags = (np.abs((x - x.mean()) / (x.std() + 1e-9)) > z_thresh).flatten()
+          flags = iso_flags | z_flags
+          tp = np.sum(flags & true_anoms)
+          fp = np.sum(flags & ~true_anoms)
+          recall = (tp / np.sum(true_anoms)) * 100 if np.sum(true_anoms) > 0 else 0.0
+          false_pos_rate = (fp / np.sum(~true_anoms)) * 100 if np.sum(~true_anoms) > 0 else 0.0
+          return {
+              "flags": flags.tolist(),
+              "recall_pct": recall,
+              "false_alarm_pct": false_pos_rate,
+              "true_anoms_detected": int(tp)
+          }
+      if __name__ == "__main__":
+          try:
+              s = list(np.random.normal(0, 1, 10000))
+              res = detect(s)
+              print(json.dumps(res, indent=2))
+          except Exception as e:
+              print(f"Error: {e}", file=sys.stderr)
+              sys.exit(1)
+      PY
+      python ${VERIF_DIR}/anomaly_stack.py | tee -a "${LOG}"
+
+  - name: Observability stack (Prometheus+Grafana+Thanos) manifests
+    run: |
+      set -euo pipefail
+      # Preprocess regions to YAML list
+      regions_list=$(python -c "import sys, yaml; print(yaml.dump({'regions': sys.argv[1].split(',')}))" "${{ inputs.regions }}")
+      cat > ${OBS_DIR}/values.yaml <<YAML
+      ${regions_list}
+      retentionDays: ${{ inputs.retention_days }}
+      grafana:
+        dashboards: ["phi_qevf_overview", "anomaly_recall", "qmp_pricing"]
+      YAML
+      cat > ${OBS_DIR}/README.md <<'MD'
+      Three-region Prometheus+Grafana with Thanos retention. Configure remote-write per region and Thanos Store.
+      Deploy with Helm: helm install obs-stack . --values values.yaml
+      MD
+      echo "Observability scaffolded: $(cat ${OBS_DIR}/values.yaml)" | tee -a "${LOG}"
+
+  - name: ORD pipeline with zstd and signed manifests
+    run: |
+      set -euo pipefail
+      cat > ${ORD_DIR}/writer.py <<'PY'
+      import json
+      import time
+      import zstandard as zstd
+      import hashlib
+      import os
+      import sys
+      from pathlib import Path
+      INTERVAL = int(os.getenv("ORD_INTERVAL_SEC", "30"))
+      CHECKPOINT_H = int(os.getenv("ORD_CHECKPOINT_HOURS", "6"))
+      out = Path("ord_out")
+      out.mkdir(exist_ok=True)
+      def write(doc, name):
+          raw = json.dumps(doc, separators=(",", ":")).encode("utf-8")
+          cctx = zstd.ZstdCompressor(level=9)
+          comp = cctx.compress(raw)
+          p = out / f"{name}.zst"
+          p.write_bytes(comp)
+          sig = hashlib.sha256(comp).hexdigest()
+          (out / f"{name}.sha256").write_text(sig)
+      def run(bounded_loops=10):
+          t0 = time.time()
+          i = 0
+          while i < bounded_loops:
+              doc = {"ts": time.time(), "metrics": {"rmse": 0.42, "mae": 0.31}}
+              write(doc, f"m_{i:06d}")
+              if (time.time() - t0) >= CHECKPOINT_H * 3600:
+                  write({"checkpoint": True, "ts": time.time()}, "checkpoint")
+                  t0 = time.time()  # Reset for next
+              time.sleep(INTERVAL)
+              i += 1
+      if __name__ == "__main__":
+          try:
+              run()
+          except Exception as e:
+              print(f"Error: {e}", file=sys.stderr)
+              sys.exit(1)
+      PY
+      ORD_INTERVAL_SEC=${{ inputs.ord_interval_sec }} ORD_CHECKPOINT_HOURS=${{ inputs.ord_checkpoint_hours }} python ${ORD_DIR}/writer.py | tee -a "${LOG}"
+
+  - name: QMP sandbox scaffolding
+    run: |
+      set -euo pipefail
+      cat > ${QMP_DIR}/qmp.py <<'PY'
+      import time
+      import json
+      import random
+      import os
+      import sys
+      BASE = float(os.getenv("QMP_BASE_PRICE_USD", "0.0004"))
+      ETA = 0.93
+      def price_stream(n=50, latency_max=60):
+          start = time.time()
+          books = []
+          for i in range(n):
+              eff = ETA + random.uniform(-0.02, 0.02)
+              p = BASE * eff
+              books.append({"ts": time.time(), "eff": eff, "price": p})
+              time.sleep(random.uniform(0, latency_max / n))  # Simulate latency
+          elapsed = time.time() - start
+          return books, float(elapsed)
+      if __name__ == "__main__":
+          try:
+              books, lat = price_stream()
+              res = {"stream": books, "total_latency_s": lat}
+              print(json.dumps(res, indent=2))
+          except Exception as e:
+              print(f"Error: {e}", file=sys.stderr)
+              sys.exit(1)
+      PY
+      QMP_BASE_PRICE_USD=${{ inputs.qmp_base_price_usd }} python ${QMP_DIR}/qmp.py | tee -a "${LOG}"
+
+  - name: Dashboards and docs
+    run: |
+      set -euo pipefail
+      mkdir -p dashboards
+      cat > dashboards/phi_qevf_overview.json <<'JSON'
+      {
+        "title": "Φ_QEVF Overview",
+        "panels": [
+          {"type": "graph", "title": "RMSE/MAE"},
+          {"type": "stat", "title": "KS Confidence"},
+          {"type": "table", "title": "Anomaly Recall"}
+        ]
+      }
+      JSON
+      cat > ${PHASE_DIR}/VI.1_README.md <<'MD'
+      Phase VI.1 artifacts: verifier outputs, ORD compressed metrics, and QMP pricing streams with audit checksums.
+      Run locally: scripts/run_phase_vi1_local.sh
+      MD
+      echo "Dashboards/docs updated" | tee -a "${LOG}"
+
+  - name: CI workflow — variance, KS, anomaly gates with fault injection
+    run: |
+      set -euo pipefail
+      cat > .github/workflows/phase_vi1_ci.yml <<'YML'
+      name: Phase VI.1 Validation
+      on: [push, pull_request, workflow_dispatch]
+      jobs:
+        validate:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                python-version: "${{ env.PYTHON_VERSION }}"
+            - run: pip install numpy scipy scikit-learn zstandard
+            - run: python ${{ env.VERIF_DIR }}/phi_qevf.py
+            - run: python ${{ env.VERIF_DIR }}/anomaly_stack.py
+            - name: ORD and QMP validation
+              run: |
+                ORD_INTERVAL_SEC=${{ inputs.ord_interval_sec }} ORD_CHECKPOINT_HOURS=${{ inputs.ord_checkpoint_hours }} python ${{ env.ORD_DIR }}/writer.py
+                QMP_BASE_PRICE_USD=${{ inputs.qmp_base_price_usd }} python ${{ env.QMP_DIR }}/qmp.py
+            - name: Evaluate thresholds and criteria
+              run: |
+                python - <<'PY'
+                import json
+                import sys
+                # Load verifier results
+                with open("out/phi_qevf_summary.json") as f:
+                    s = json.load(f)
+                assert s["ks_confidence_pct"] >= ${{ inputs.ks_confidence }}, f"KS confidence {s['ks_confidence_pct']:.1f}% below ${{ inputs.ks_confidence }}%"
+                assert s["adaptive_tolerance_pct"] >= ${{ inputs.tol_floor_pct }}, f"Adaptive tolerance {s['adaptive_tolerance_pct']:.1f}% below floor ${{ inputs.tol_floor_pct }}%"
+                assert s["variance_pct"] < 5.0, f"Variance {s['variance_pct']:.1f}% exceeds 5%"
+                print("Verifier thresholds OK:", s)
+                # Load anomaly results (run and capture)
+                import subprocess
+                anomaly_out = subprocess.check_output(["python", "${VERIF_DIR}/anomaly_stack.py"]).decode()
+                a = json.loads(anomaly_out)
+                assert a["recall_pct"] >= 95.0, f"Recall {a['recall_pct']:.1f}% below 95%"
+                assert a["false_alarm_pct"] < 1.0, f"False alarms {a['false_alarm_pct']:.1f}% exceeds 1%"
+                print("Anomaly thresholds OK:", a)
+                PY
+      YML
+      echo "CI workflow scaffolded with gates" | tee -a "${LOG}"
+
+  - name: README update
+    run: |
+      set -euo pipefail
+      ORD_INTERVAL="${{ inputs.ord_interval_sec }}"
+      ORD_CHECKPOINT="${{ inputs.ord_checkpoint_hours }}"
+      RETENTION="${{ inputs.retention_days }}"
+      EPH="${{ inputs.qmp_base_price_usd }}"
+      python - <<PY
+      from pathlib import Path
+      section = f"""## Phase VI.1 Operationalization (Automated)
+      - Φ_QEVF verifier harness added (RMSE/MAE/variance, KS confidence with scipy)
+      - ORD pipeline (zstd + signed manifests) at {ORD_INTERVAL}s with {ORD_CHECKPOINT}h checkpoints
+      - Three-region observability manifests (Prometheus/Grafana/Thanos), retention {RETENTION}d
+      - QMP sandbox streams base EPH price {EPH} USD with efficiency factor 0.93±0.02
+      - CI gates: variance <5%, recall ≥95%, false positives <1%
+      """
+      readme = Path("README.md").read_text(encoding='utf-8') if Path("README.md").exists() else "# QuASIM × QuNimbus\n"
+      readme += "\n" + section
+      Path("README.md").write_text(readme, encoding='utf-8')
+      print("README updated")
+      PY
+      | tee -a "${LOG}"
+
+  - name: Phase VII scaffolding
+    run: |
+      set -euo pipefail
+      mkdir -p ${PHASE_DIR}/VII
+      cat > ${PHASE_DIR}/VII/scaffold.yaml <<'YML'
+      # Phase VII Prep: Migration hooks for QuNimbus v2
+      tasks:
+        - migrate_ord_to_federated
+        - integrate_qmp_with_phase_vii_oracles
+      YML
+      echo "Phase VII scaffold added: ${PHASE_DIR}/VII/scaffold.yaml" | tee -a "${LOG}"
+
+  - name: Validate success criteria and checksum artifacts
+    run: |
+      set -euo pipefail
+      # Run key binaries and check outputs
+      python ${VERIF_DIR}/phi_qevf.py && [[ -f out/phi_qevf_summary.json.sha256 ]]
+      python ${VERIF_DIR}/anomaly_stack.py
+      ORD_INTERVAL_SEC=${{ inputs.ord_interval_sec }} python ${ORD_DIR}/writer.py && ls ord_out/*.zst.sha256
+      QMP_BASE_PRICE_USD=${{ inputs.qmp_base_price_usd }} python ${QMP_DIR}/qmp.py
+      # Summary report
+      report=$(jq -n --arg r "${{ inputs.regions }}" --arg ret "${{ inputs.retention_days }}" '{status: "success", regions: $r, retention_days: $ret, artifacts: $(find tools infra -maxdepth 2 -type f -name "*.py" -o -name "*.yaml" -o -name "*.json" | wc -l)}')
+      echo "${report}" | tee out/summary.json "${LOG}"
+      echo "All criteria validated; see out/summary.json" | tee -a "${LOG}"
+
+  - name: Final summary
+    run: |
+      set -euo pipefail
+      echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') Phase VI.1 operationalization complete" | tee -a "${LOG}"
+      echo "Key outputs: $(find out -type f | tr '\n' ' ')"

--- a/.github/workflows/phase_vi1_ci.yml
+++ b/.github/workflows/phase_vi1_ci.yml
@@ -1,0 +1,45 @@
+name: Phase VI.1 Validation
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.12"
+      VERIF_DIR: tools/phi_qevf
+      ORD_DIR: infra/ord_pipeline
+      QMP_DIR: tools/qmp_sandbox
+      KS_CONFIDENCE: "95"
+      TOL_FLOOR: "2"
+      ORD_INTERVAL_SEC: "30"
+      ORD_CHECKPOINT_HOURS: "6"
+      QMP_BASE_PRICE_USD: "0.0004"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+      - run: pip install numpy scipy scikit-learn zstandard
+      - run: python ${{ env.VERIF_DIR }}/phi_qevf.py
+      - run: python ${{ env.VERIF_DIR }}/anomaly_stack.py
+      - name: ORD and QMP validation
+        run: |
+          ORD_INTERVAL_SEC=${{ env.ORD_INTERVAL_SEC }} ORD_CHECKPOINT_HOURS=${{ env.ORD_CHECKPOINT_HOURS }} python ${{ env.ORD_DIR }}/writer.py
+          QMP_BASE_PRICE_USD=${{ env.QMP_BASE_PRICE_USD }} python ${{ env.QMP_DIR }}/qmp.py
+      - name: Evaluate thresholds and criteria
+        run: |
+          python - <<'PY'
+          import json
+          import subprocess
+          with open("out/phi_qevf_summary.json") as f:
+              s = json.load(f)
+          assert s["ks_confidence_pct"] >= float("${{ env.KS_CONFIDENCE }}"), f"KS confidence {s['ks_confidence_pct']:.1f}% below ${{ env.KS_CONFIDENCE }}%"
+          assert s["adaptive_tolerance_pct"] >= float("${{ env.TOL_FLOOR }}"), f"Adaptive tolerance {s['adaptive_tolerance_pct']:.1f}% below floor ${{ env.TOL_FLOOR }}%"
+          assert s["variance_pct"] < 5.0, f"Variance {s['variance_pct']:.1f}% exceeds 5%"
+          print("Verifier thresholds OK:", s)
+          anomaly_out = subprocess.check_output(["python", "${{ env.VERIF_DIR }}/anomaly_stack.py"]).decode()
+          a = json.loads(anomaly_out)
+          assert a["recall_pct"] >= 95.0, f"Recall {a['recall_pct']:.1f}% below 95%"
+          assert a["false_alarm_pct"] < 1.0, f"False alarms {a['false_alarm_pct']:.1f}% exceeds 1%"
+          print("Anomaly thresholds OK:", a)
+          PY

--- a/README.md
+++ b/README.md
@@ -261,3 +261,10 @@ F --> G[Observability Stack (Grafana/Prometheus)]
   <sub>© 2025 <b>QuASIM × QuNimbus</b> — Quantum-Classical Infrastructure for the Aerospace Era.</sub><br>
   <a href="LICENSE">Apache 2.0 License</a> • <a href="https://quasim.io">Website</a>
 </p>
+
+## Phase VI.1 Operationalization (Automated)
+- Φ_QEVF verifier harness added (RMSE/MAE/variance, KS confidence with scipy)
+- ORD pipeline (zstd + signed manifests) at 30s with 6h checkpoints
+- Three-region observability manifests (Prometheus/Grafana/Thanos), retention 90d
+- QMP sandbox streams base EPH price 0.0004 USD with efficiency factor 0.93±0.02
+- CI gates: variance <5%, recall ≥95%, false positives <1%

--- a/dashboards/phi_qevf_overview.json
+++ b/dashboards/phi_qevf_overview.json
@@ -1,0 +1,8 @@
+{
+  "title": "Φ_QEVF Overview",
+  "panels": [
+    {"type": "graph", "title": "RMSE/MAE"},
+    {"type": "stat", "title": "KS Confidence"},
+    {"type": "table", "title": "Anomaly Recall"}
+  ]
+}

--- a/docs/phase/VI.1_README.md
+++ b/docs/phase/VI.1_README.md
@@ -1,0 +1,2 @@
+Phase VI.1 artifacts: verifier outputs, ORD compressed metrics, and QMP pricing streams with audit checksums.
+Run locally: scripts/run_phase_vi1_local.sh

--- a/docs/phase/VI.1_status.md
+++ b/docs/phase/VI.1_status.md
@@ -1,0 +1,2 @@
+# Phase VI.1 Status (placeholder)
+Provide your status brief here or keep using the in-repo version.

--- a/docs/phase/VII/scaffold.yaml
+++ b/docs/phase/VII/scaffold.yaml
@@ -1,0 +1,4 @@
+# Phase VII Prep: Migration hooks for QuNimbus v2
+tasks:
+  - migrate_ord_to_federated
+  - integrate_qmp_with_phase_vii_oracles

--- a/infra/observability/README.md
+++ b/infra/observability/README.md
@@ -1,0 +1,2 @@
+Three-region Prometheus+Grafana with Thanos retention. Configure remote-write per region and Thanos Store.
+Deploy with Helm: helm install obs-stack . --values values.yaml

--- a/infra/observability/values.yaml
+++ b/infra/observability/values.yaml
@@ -1,0 +1,7 @@
+regions:
+- us-east-1
+- eu-central-1
+- ap-southeast-1
+retentionDays: 90
+grafana:
+  dashboards: ["phi_qevf_overview", "anomaly_recall", "qmp_pricing"]

--- a/infra/ord_pipeline/writer.py
+++ b/infra/ord_pipeline/writer.py
@@ -1,0 +1,41 @@
+import json
+import time
+import zstandard as zstd
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+INTERVAL = int(os.getenv("ORD_INTERVAL_SEC", "30"))
+CHECKPOINT_H = int(os.getenv("ORD_CHECKPOINT_HOURS", "6"))
+
+out = Path("ord_out")
+out.mkdir(exist_ok=True)
+
+def write(doc, name):
+    raw = json.dumps(doc, separators=(",", ":")).encode("utf-8")
+    cctx = zstd.ZstdCompressor(level=9)
+    comp = cctx.compress(raw)
+    p = out / f"{name}.zst"
+    p.write_bytes(comp)
+    sig = hashlib.sha256(comp).hexdigest()
+    (out / f"{name}.sha256").write_text(sig)
+
+def run(bounded_loops=10):
+    t0 = time.time()
+    i = 0
+    while i < bounded_loops:
+        doc = {"ts": time.time(), "metrics": {"rmse": 0.42, "mae": 0.31}}
+        write(doc, f"m_{i:06d}")
+        if (time.time() - t0) >= CHECKPOINT_H * 3600:
+            write({"checkpoint": True, "ts": time.time()}, "checkpoint")
+            t0 = time.time()  # Reset for next
+        time.sleep(INTERVAL)
+        i += 1
+
+if __name__ == "__main__":
+    try:
+        run()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/run_phase_vi1_local.sh
+++ b/scripts/run_phase_vi1_local.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHON_VERSION=3.12
+export ORD_INTERVAL_SEC=${ORD_INTERVAL_SEC:-30}
+export ORD_CHECKPOINT_HOURS=${ORD_CHECKPOINT_HOURS:-6}
+export QMP_BASE_PRICE_USD=${QMP_BASE_PRICE_USD:-0.0004}
+
+pip install numpy scipy scikit-learn zstandard
+python tools/phi_qevf/phi_qevf.py
+python tools/phi_qevf/anomaly_stack.py
+QMP_BASE_PRICE_USD=${QMP_BASE_PRICE_USD} python tools/qmp_sandbox/qmp.py > out/qmp_stream.json
+ORD_INTERVAL_SEC=${ORD_INTERVAL_SEC} ORD_CHECKPOINT_HOURS=${ORD_CHECKPOINT_HOURS} python infra/ord_pipeline/writer.py
+# Quick validation
+python -c "
+import json
+s = json.load(open('out/phi_qevf_summary.json'))
+print(f'KS: {s[\"ks_confidence_pct\"]:.1f}%, Pass: {s[\"pass\"]}')
+"
+echo "Local run complete. Check out/ for outputs."

--- a/tools/phi_qevf/anomaly_stack.py
+++ b/tools/phi_qevf/anomaly_stack.py
@@ -1,0 +1,36 @@
+import numpy as np
+import json
+from sklearn.ensemble import IsolationForest
+import sys
+
+def detect(series, z_thresh=3.5, contamination=0.01):
+    x = np.array(series).reshape(-1, 1)
+    # Inject known anomalies for metric eval
+    clean_x = x.copy()
+    anomaly_indices = [123, 4567]  # Known injections
+    x[anomaly_indices] = [8, -7] if len(x) > 4567 else x[anomaly_indices] + 10
+    true_anoms = np.zeros(len(x), dtype=bool)
+    true_anoms[anomaly_indices[:len(x)]] = True
+    iforest = IsolationForest(n_estimators=100, contamination=contamination, random_state=42).fit(x)
+    iso_flags = (iforest.predict(x) == -1)
+    z_flags = (np.abs((x - x.mean()) / (x.std() + 1e-9)) > z_thresh).flatten()
+    flags = iso_flags | z_flags
+    tp = np.sum(flags & true_anoms)
+    fp = np.sum(flags & ~true_anoms)
+    recall = (tp / np.sum(true_anoms)) * 100 if np.sum(true_anoms) > 0 else 0.0
+    false_pos_rate = (fp / np.sum(~true_anoms)) * 100 if np.sum(~true_anoms) > 0 else 0.0
+    return {
+        "flags": flags.tolist(),
+        "recall_pct": recall,
+        "false_alarm_pct": false_pos_rate,
+        "true_anoms_detected": int(tp)
+    }
+
+if __name__ == "__main__":
+    try:
+        s = list(np.random.normal(0, 1, 10000))
+        res = detect(s)
+        print(json.dumps(res, indent=2))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/tools/phi_qevf/phi_qevf.py
+++ b/tools/phi_qevf/phi_qevf.py
@@ -1,0 +1,53 @@
+import numpy as np
+import json
+import hashlib
+from pathlib import Path
+from scipy.stats import ks_2samp
+import sys
+
+def rmse(a, b):
+    a, b = np.array(a), np.array(b)
+    return float(np.sqrt(np.mean((a - b) ** 2)))
+
+def mae(a, b):
+    a, b = np.array(a), np.array(b)
+    return float(np.mean(np.abs(a - b)))
+
+def variance(a):
+    a = np.array(a)
+    return float(np.var(a))
+
+def ks_confidence(a, b, alpha=0.05):
+    # KS p-value to confidence: 100 * (1 - alpha if p >= alpha else 0)
+    stat, p = ks_2samp(a, b)
+    return float(100 * (1 if p >= alpha else 0))
+
+def verify(trace, ref, tol_floor=0.02):
+    r = {
+        "rmse": rmse(trace, ref),
+        "mae": mae(trace, ref),
+        "variance_pct": variance(trace) * 100.0,
+        "ks_confidence_pct": ks_confidence(trace, ref)
+    }
+    r["adaptive_tolerance_pct"] = max(tol_floor * 100.0, np.sqrt(r["variance_pct"]))
+    r["pass"] = (r["ks_confidence_pct"] >= 95.0) and (r["variance_pct"] < 5.0)
+    return r
+
+def write_signed(path, obj):
+    b = json.dumps(obj, indent=2).encode('utf-8')
+    Path(path).write_bytes(b)
+    sig = hashlib.sha256(b).hexdigest()
+    Path(str(path) + ".sha256").write_text(sig)
+
+if __name__ == "__main__":
+    try:
+        n = 10000
+        ref = np.sin(np.linspace(0, 100, n))
+        trace = ref + np.random.normal(0, 0.003, size=n)
+        res = verify(trace, ref, tol_floor=0.02)
+        Path("out").mkdir(exist_ok=True)
+        write_signed("out/phi_qevf_summary.json", res)
+        print(json.dumps(res, indent=2))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/tools/qmp_sandbox/qmp.py
+++ b/tools/qmp_sandbox/qmp.py
@@ -1,0 +1,28 @@
+import time
+import json
+import random
+import os
+import sys
+
+BASE = float(os.getenv("QMP_BASE_PRICE_USD", "0.0004"))
+ETA = 0.93
+
+def price_stream(n=50, latency_max=60):
+    start = time.time()
+    books = []
+    for i in range(n):
+        eff = ETA + random.uniform(-0.02, 0.02)
+        p = BASE * eff
+        books.append({"ts": time.time(), "eff": eff, "price": p})
+        time.sleep(random.uniform(0, latency_max / n))  # Simulate latency
+    elapsed = time.time() - start
+    return books, float(elapsed)
+
+if __name__ == "__main__":
+    try:
+        books, lat = price_stream()
+        res = {"stream": books, "total_latency_s": lat}
+        print(json.dumps(res, indent=2))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add a Copilot agent task to operationalize Phase VI.1 with verifier, observability, ORD, and QMP artifacts
- scaffold verifier, anomaly detection, observability manifests, ORD writer, QMP sandbox, dashboards, and docs
- wire a CI workflow, README entry, Phase VII scaffold, and local runner for the new automation

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a52df71c832bbeb8aef5231bfa56)