### PR TITLE
Complete QNX substrate wiring with modern backend

### DIFF
--- a/.github/workflows/qnx-ci.yml
+++ b/.github/workflows/qnx-ci.yml
@@ -1,0 +1,33 @@
+name: QNX substrate CI
+
+on:
+  push:
+    paths:
+      - "qnx/**"
+      - "tests/qnx/**"
+      - ".github/workflows/qnx-ci.yml"
+  pull_request:
+    paths:
+      - "qnx/**"
+      - "tests/qnx/**"
+      - ".github/workflows/qnx-ci.yml"
+
+jobs:
+  test-qnx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Run QNX smoke tests
+        run: |
+          pytest tests/qnx/ -v

--- a/README.md
+++ b/README.md
@@ -423,3 +423,42 @@ Compliance documentation: `docs/QUNIMBUS_NIST_800_53_COMPLIANCE.md`
 - Three-region observability manifests (Prometheus/Grafana/Thanos), retention 90d
 - QMP sandbox streams base EPH price 0.0004 USD with efficiency factor 0.93±0.02
 - CI gates: variance <5%, recall ≥95%, false positives <1%
+
+## QNX substrate (additive orchestration layer)
+
+This repository includes an *optional* `qnx` package that provides a small,
+additive orchestration layer on top of the existing QuASIM implementation.
+
+The QNX substrate does **not** change any existing public APIs; it offers a
+unified way to route simulations to different engines and compare their outputs
+using a common result type.
+
+The modern backend builds deterministic circuits via
+`quasim.api.scenarios.build_circuit` and executes them through
+`quantum.python.quasim_sim.simulate`, so repeated runs with identical inputs
+produce stable hashes for auditing.
+
+Example (Python):
+
+```python
+from qnx import QNXSubstrate, SimulationConfig, SecurityLevel
+
+cfg = SimulationConfig(
+    scenario_id="smoke",
+    timesteps=10,
+    seed=42,
+    security_level=SecurityLevel.INTERNAL,
+    backend="quasim_modern",
+)
+
+substrate = QNXSubstrate()
+result = substrate.run_simulation(cfg)
+
+print(result.backend, result.simulation_hash)
+```
+
+Example (CLI, once wired into packaging):
+
+```bash
+qnx simulate --scenario smoke --timesteps 10 --backend quasim_modern
+```

--- a/docs/qnx_integration/01_qnx_architecture.md
+++ b/docs/qnx_integration/01_qnx_architecture.md
@@ -1,0 +1,59 @@
+# QNX substrate architecture
+
+The QNX substrate is an additive orchestration layer that lets QuASIM route
+simulations to multiple execution engines while keeping a unified interface and
+result shape. It does not change existing public APIs and can be adopted
+incrementally.
+
+## Layering overview
+
+```
+QNX SUBSTRATE
+  ├─ QuASIM (modern)
+  ├─ QuASIM v1.2.0 (legacy)
+  └─ QVR Windows runtime
+```
+
+The substrate chooses a backend at runtime and returns a
+`SubstrateResult` that records which backend ran along with hashing,
+execution timing, and (optionally) carbon estimates.
+
+## Key types
+
+* `qnx.types.SimulationConfig` — configuration for a simulation run; includes
+  scenario identifier, timesteps, seed, security level, and backend selection.
+* `qnx.types.SubstrateResult` — normalized result structure containing backend
+  name, simulation hash, elapsed time, carbon estimate, and raw backend output.
+* `qnx.backends.get_backend_registry()` — discovers available backends and makes
+  them selectable via the `backend` field on `SimulationConfig`.
+
+## Backends provided
+
+The substrate currently exposes three adapters:
+
+* `quasim_modern` — runs the current QuASIM runtime via
+  `quantum.python.quasim_sim.simulate` and a deterministic scenario builder
+  defined in `quasim.api.scenarios`.
+* `quasim_legacy_v1_2_0` — stub for the 1.2.0 legacy engine to enable regression
+  comparison wiring later.
+* `qvr_win` — Windows-only bridge to the QVR runtime, assuming JSON input/output
+  over a CLI process.
+
+Each backend implements the `SimulationBackend` protocol and returns structured
+content that is wrapped into a `SubstrateResult` by `QNXSubstrate`.
+
+## CLI surface
+
+A minimal CLI is available to run simulations without writing Python code:
+
+```bash
+qnx simulate \
+  --scenario smoke \
+  --timesteps 100 \
+  --seed 42 \
+  --backend quasim_modern
+```
+
+The CLI constructs a `SimulationConfig`, runs the substrate, and prints a small
+summary including backend name, simulation hash prefix, execution time, and
+estimated CO₂.

--- a/docs/qnx_integration/02_qnx_scenarios.md
+++ b/docs/qnx_integration/02_qnx_scenarios.md
@@ -1,0 +1,34 @@
+# QNX scenarios and circuit generation
+
+The QNX substrate builds small, deterministic circuits from a
+`SimulationConfig` before invoking the modern QuASIM runtime. This keeps hashes
+stable and makes regression comparisons straightforward.
+
+## ScenarioSpec
+
+`quasim.api.scenarios.ScenarioSpec` captures the inputs needed to construct a
+circuit:
+
+- `scenario_id`: logical identifier for the scenario
+- `timesteps`: number of gates/steps to generate
+- `seed`: RNG seed to keep outputs deterministic
+- `extra`: optional dictionary for future extensions
+
+## `build_circuit`
+
+`quasim.api.scenarios.build_circuit(spec)` maps the spec to a synthetic circuit:
+
+- Uses `random.Random(spec.seed)` for reproducibility.
+- Applies a small scenario-dependent multiplier derived from `scenario_id`.
+- Emits `timesteps` rows of complex values (two entries per row by default).
+
+The resulting circuit is suitable for `quantum.python.quasim_sim.simulate` and
+remains stable for identical inputs.
+
+## Engine wiring
+
+- The modern backend (`qnx.backends.quasim_modern`) constructs a
+  `ScenarioSpec`, builds the circuit, and calls `quasim_sim.simulate` with
+  `precision="fp8"`.
+- Legacy and QVR adapters are present as stubs/placeholders, but they follow the
+  same scenario contract so they can be upgraded without breaking callers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,11 @@ quasim-qgh = "quasim.cli.qgh_cli:cli"
 quasim-terc-obs = "quasim.cli.terc_obs_cli:cli"
 quasim-own = "quasim.cli.quasim_own:cli"
 qunimbus = "quasim.qunimbus.cli:main"
+qnx = "qnx.cli:cli"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["quasim*"]
+include = ["quasim*", "qnx*"]
 
 [tool.black]
 line-length = 100

--- a/qnx/__init__.py
+++ b/qnx/__init__.py
@@ -1,0 +1,18 @@
+"""QNX substrate package for orchestrating QuASIM simulations.
+
+This package provides a pluggable substrate that can dispatch simulations to
+multiple backends (modern, legacy, and QVR) while producing a normalized result
+record.
+"""
+
+from .core import QNXSubstrate
+from .types import SimulationConfig, SubstrateResult, SecurityLevel
+
+__all__ = [
+    "QNXSubstrate",
+    "SimulationConfig",
+    "SubstrateResult",
+    "SecurityLevel",
+]
+
+__version__ = "3.0.0"

--- a/qnx/backends/__init__.py
+++ b/qnx/backends/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from ..logging import get_logger
+from ..types import SimulationBackend
+from .qvr_win import QVRWinBackend
+from .quasim_legacy_v120 import QuasimLegacyV120Backend
+from .quasim_modern import QuasimModernBackend
+
+logger = get_logger(__name__)
+
+
+def _safe_init(backend_cls: type[SimulationBackend]) -> SimulationBackend | None:
+    try:
+        return backend_cls()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.info("Skipping backend during initialisation", extra={"backend": backend_cls.__name__, "error": str(exc)})
+        return None
+
+
+def get_backend_registry() -> Dict[str, SimulationBackend]:
+    """Initialise all available backends and return them keyed by name."""
+
+    registry: Dict[str, SimulationBackend] = {}
+    for backend_cls in (QuasimModernBackend, QuasimLegacyV120Backend, QVRWinBackend):
+        backend = _safe_init(backend_cls)
+        if backend is not None:
+            registry[backend.name] = backend
+    return registry
+
+__all__ = ["get_backend_registry"]

--- a/qnx/backends/quasim_legacy_v120.py
+++ b/qnx/backends/quasim_legacy_v120.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import MutableMapping
+
+from ..types import SimulationConfig
+
+
+class QuasimLegacyV120Backend:
+    """Stub adapter for the legacy QuASIM v1.2.0 engine."""
+
+    name = "quasim_legacy_v1_2_0"
+
+    def run(self, config: SimulationConfig) -> MutableMapping[str, object]:
+        seed = config.seed if config.seed is not None else 0
+        return {
+            "engine": self.name,
+            "scenario_id": config.scenario_id,
+            "timesteps": config.timesteps,
+            "seed": seed,
+            "status": "not_implemented",
+            "note": "Legacy v1.2.0 wiring TODO.",
+        }
+
+    def validate(self, config: SimulationConfig) -> bool:
+        return False
+
+
+__all__ = ["QuasimLegacyV120Backend"]

--- a/qnx/backends/quasim_modern.py
+++ b/qnx/backends/quasim_modern.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import MutableMapping
+
+from quasim.api.scenarios import ScenarioSpec
+from quasim.api.simulate import run_scenario
+
+from ..types import SimulationConfig
+
+
+class QuasimModernBackend:
+    """Backend targeting the current QuASIM engine via the scenario API."""
+
+    name = "quasim_modern"
+
+    def run(self, config: SimulationConfig) -> MutableMapping[str, object]:
+        seed = config.seed if config.seed is not None else 0
+        spec = ScenarioSpec(
+            scenario_id=config.scenario_id,
+            timesteps=config.timesteps,
+            seed=seed,
+            extra=dict(config.parameters or {}),
+        )
+        result = run_scenario(
+            scenario_id=spec.scenario_id,
+            timesteps=spec.timesteps,
+            seed=spec.seed,
+            engine=self.name,
+            extra=spec.extra,
+        )
+        payload = result.to_dict()
+        payload.setdefault("raw_output", {}).setdefault("metadata", {}).update(
+            {"security_level": config.security_level.value}
+        )
+        return payload
+
+    def validate(self, config: SimulationConfig) -> bool:
+        try:
+            smoke_config = SimulationConfig(
+                scenario_id=config.scenario_id,
+                timesteps=1,
+                seed=config.seed if config.seed is not None else 0,
+                backend=config.backend,
+                parameters=config.parameters,
+                security_level=config.security_level,
+            )
+            self.run(smoke_config)
+            return True
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+
+__all__ = ["QuasimModernBackend"]

--- a/qnx/backends/qvr_win.py
+++ b/qnx/backends/qvr_win.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import MutableMapping
+
+from ..types import SimulationConfig
+
+
+class QVRWinBackend:
+    """Windows-only backend bridging to the QVR CLI."""
+
+    name = "qvr_win"
+
+    def run(self, config: SimulationConfig) -> MutableMapping[str, object]:
+        if _is_windows() is False:  # pragma: no cover - platform-specific
+            raise RuntimeError("QVRWinBackend is only usable on Windows hosts.")
+
+        executable = os.environ.get("QVR_EXECUTABLE", "qvr.exe")
+        if not Path(executable).exists():
+            raise FileNotFoundError(f"QVR executable not found at '{executable}'")
+
+        payload = {
+            "scenario_id": config.scenario_id,
+            "timesteps": config.timesteps,
+            "seed": config.seed if config.seed is not None else 0,
+        }
+
+        proc = subprocess.run(
+            [executable],
+            input=json.dumps(payload).encode(),
+            capture_output=True,
+            check=False,
+        )
+
+        stdout = proc.stdout.decode(errors="replace")
+        stderr = proc.stderr.decode(errors="replace")
+
+        try:
+            parsed = json.loads(stdout) if stdout else {}
+        except json.JSONDecodeError:
+            parsed = {"raw_stdout": stdout}
+
+        return {
+            "engine": self.name,
+            "scenario_id": config.scenario_id,
+            "timesteps": config.timesteps,
+            "seed": payload["seed"],
+            "payload": parsed,
+            "stderr": stderr,
+            "returncode": proc.returncode,
+        }
+
+    def validate(self, config: SimulationConfig) -> bool:
+        if _is_windows() is False:  # pragma: no cover - platform-specific
+            return False
+        executable = os.environ.get("QVR_EXECUTABLE", "qvr.exe")
+        return Path(executable).exists()
+
+
+__all__ = ["QVRWinBackend"]
+
+
+def _is_windows() -> bool:
+    """Return True when running on a Windows host."""
+
+    return os.name == "nt"

--- a/qnx/cli.py
+++ b/qnx/cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .core import QNXSubstrate
+from .types import SimulationConfig
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run QNX simulations across multiple backends")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    simulate = subparsers.add_parser("simulate", help="Run a simulation")
+    simulate.add_argument("--scenario", required=True, help="Scenario identifier")
+    simulate.add_argument("--timesteps", type=int, default=1, help="Number of timesteps to simulate")
+    simulate.add_argument("--seed", type=int, default=None, help="Optional random seed")
+    simulate.add_argument(
+        "--backend",
+        default="quasim_modern",
+        choices=["quasim_modern", "quasim_legacy_v1_2_0", "qvr_win"],
+        help="Backend to execute",
+    )
+    return parser
+
+
+def cli(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    substrate = QNXSubstrate()
+    config = SimulationConfig(
+        scenario_id=args.scenario,
+        timesteps=args.timesteps,
+        seed=args.seed,
+        backend=args.backend,
+    )
+    result = substrate.run_simulation(config)
+
+    print(
+        json.dumps(
+            {
+                "backend": result.backend,
+                "hash": result.simulation_hash[:12],
+                "execution_time_ms": round(result.execution_time_ms, 2),
+                "carbon_emissions_kg": result.carbon_emissions_kg,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(cli())

--- a/qnx/core.py
+++ b/qnx/core.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, MutableMapping
+
+from .backends import get_backend_registry
+from .logging import get_logger
+from .security import compute_integrity_hash, validate_security_context
+from .sustainability import estimate_carbon
+from .types import SimulationConfig, SubstrateResult
+
+logger = get_logger(__name__)
+
+
+class QNXSubstrate:
+    """Coordinator for running simulations across multiple backends."""
+
+    def __init__(self) -> None:
+        self.backends = get_backend_registry()
+        logger.info("QNXSubstrate initialised with backends", extra={"backends": list(self.backends)})
+
+    def run_simulation(self, config: SimulationConfig) -> SubstrateResult:
+        """Run a simulation on the configured backend and return a structured result."""
+
+        backend = self.backends.get(config.backend)
+        if backend is None:
+            raise ValueError(f"Backend '{config.backend}' is not available")
+
+        validate_security_context(config.security_level)
+
+        logger.info(
+            "Running simulation",
+            extra={"backend": config.backend, "scenario_id": config.scenario_id, "timesteps": config.timesteps},
+        )
+
+        start = time.perf_counter()
+        raw_results = backend.run(config)
+        execution_time_ms = (time.perf_counter() - start) * 1000
+
+        hash_payload: MutableMapping[str, Any] = {
+            "backend": config.backend,
+            "scenario_id": config.scenario_id,
+            "timesteps": config.timesteps,
+            "seed": config.seed,
+            "raw_results": raw_results,
+        }
+        simulation_hash = compute_integrity_hash(json.dumps(hash_payload, sort_keys=True, default=str))
+        carbon_emissions = estimate_carbon(raw_results)
+
+        errors = []
+        warnings = []
+        if isinstance(raw_results, dict):
+            if raw_results.get("status") == "error":
+                errors.append("backend_reported_error")
+            if "warnings" in raw_results and isinstance(raw_results["warnings"], list):
+                warnings.extend(raw_results["warnings"])
+
+        return SubstrateResult(
+            backend=config.backend,
+            scenario_id=config.scenario_id,
+            timesteps=config.timesteps,
+            seed=config.seed,
+            raw_results=raw_results,
+            simulation_hash=simulation_hash,
+            execution_time_ms=execution_time_ms,
+            carbon_emissions_kg=carbon_emissions,
+            errors=errors,
+            warnings=warnings,
+        )

--- a/qnx/logging.py
+++ b/qnx/logging.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+
+class JSONFormatter(logging.Formatter):
+    """A small JSON formatter for structured logging."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        payload: dict[str, Any] = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured with a JSON formatter."""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(JSONFormatter())
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger

--- a/qnx/security.py
+++ b/qnx/security.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any
+
+from .types import SecurityLevel
+
+
+def validate_security_context(level: SecurityLevel) -> None:
+    """Placeholder for security hooks.
+
+    The function currently performs no enforcement but provides a place to add
+    validation logic when integrating with restricted environments.
+    """
+
+
+def compute_integrity_hash(data: Any) -> str:
+    """Compute a deterministic integrity hash for the provided data."""
+
+    serialized = str(data).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def verify_integrity(data: Any, expected_hash: str) -> bool:
+    """Verify that the computed hash matches the expected value."""
+
+    actual = compute_integrity_hash(data)
+    return hmac.compare_digest(actual, expected_hash)

--- a/qnx/sustainability.py
+++ b/qnx/sustainability.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .logging import get_logger
+
+try:  # pragma: no cover - optional dependency
+    from codecarbon import EmissionsTracker
+except Exception:  # pragma: no cover - optional dependency
+    EmissionsTracker = None  # type: ignore
+
+logger = get_logger(__name__)
+
+
+def estimate_carbon(results: Any) -> float:
+    """Estimate carbon emissions for a simulation result.
+
+    If CodeCarbon is available the emissions are measured; otherwise ``0.0`` is
+    returned to avoid introducing a hard dependency.
+    """
+
+    if EmissionsTracker is None:
+        logger.info("CodeCarbon not installed; returning zero emissions estimate")
+        time.sleep(0.01)
+        return 0.0
+
+    tracker = EmissionsTracker(measure_power_secs=1)
+    tracker.start()
+    try:
+        time.sleep(0.01)
+    finally:
+        emissions = tracker.stop() or 0.0
+    return float(emissions)

--- a/qnx/types.py
+++ b/qnx/types.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, MutableMapping, Protocol
+
+
+class SecurityLevel(str, Enum):
+    """Security level for running simulations."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass
+class SimulationConfig:
+    """Configuration for running a simulation on the QNX substrate."""
+
+    scenario_id: str
+    timesteps: int
+    seed: int | None = None
+    backend: str = "quasim_modern"
+    parameters: Mapping[str, Any] | None = None
+    security_level: SecurityLevel = SecurityLevel.LOW
+
+
+@dataclass
+class SubstrateResult:
+    """Structured result returned by the QNX substrate."""
+
+    backend: str
+    scenario_id: str
+    timesteps: int
+    seed: int | None
+    raw_results: MutableMapping[str, Any]
+    simulation_hash: str
+    execution_time_ms: float
+    carbon_emissions_kg: float
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+class SimulationBackend(Protocol):
+    """Protocol all simulation backends must implement."""
+
+    name: str
+
+    def run(self, config: SimulationConfig) -> MutableMapping[str, Any]:
+        """Execute the simulation with the provided configuration."""
+
+    def validate(self, config: SimulationConfig) -> bool:  # pragma: no cover - interface
+        """Return True if the backend is operational for the given config."""

--- a/quasim/api/scenarios.py
+++ b/quasim/api/scenarios.py
@@ -1,0 +1,67 @@
+"""Deterministic scenario-to-circuit helpers for QuASIM simulations.
+
+The functions in this module provide a stable mapping from a scenario identifier
+plus basic parameters to a synthetic circuit representation that can be executed
+by :func:`quantum.python.quasim_sim.simulate`.
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class ScenarioSpec:
+    """Specification describing a simulation scenario.
+
+    Attributes
+    ----------
+    scenario_id: str
+        Logical identifier for the scenario to build.
+    timesteps: int
+        Number of timesteps or gates to generate in the circuit.
+    seed: int
+        Seed used to ensure deterministic circuit generation.
+    extra: dict[str, Any]
+        Optional additional parameters for the scenario builder.
+    """
+
+    scenario_id: str
+    timesteps: int
+    seed: int
+    extra: Dict[str, Any]
+
+
+def _base_pattern(rng: random.Random, width: int = 2) -> List[complex]:
+    """Create a small deterministic pattern of complex numbers."""
+
+    return [complex(rng.random(), rng.random()) for _ in range(width)]
+
+
+def _scenario_variant(rng: random.Random, scenario_id: str) -> float:
+    """Return a deterministic multiplier derived from the scenario id."""
+
+    return (sum(ord(ch) for ch in scenario_id) % 7 + 1) / 5.0
+
+
+def build_circuit(spec: ScenarioSpec) -> List[List[complex]]:
+    """Build a deterministic synthetic circuit from a :class:`ScenarioSpec`.
+
+    The resulting circuit is a list of timesteps, each containing a small list
+    of complex values. While synthetic, this structure exercises the runtime and
+    remains stable for a given ``(scenario_id, timesteps, seed)`` tuple.
+    """
+
+    rng = random.Random(spec.seed)
+    circuit: List[List[complex]] = []
+    multiplier = _scenario_variant(rng, spec.scenario_id)
+
+    for _ in range(max(1, spec.timesteps)):
+        base_gate = _base_pattern(rng)
+        circuit.append([value * multiplier for value in base_gate])
+
+    return circuit
+
+
+__all__ = ["ScenarioSpec", "build_circuit"]

--- a/quasim/api/simulate.py
+++ b/quasim/api/simulate.py
@@ -1,0 +1,105 @@
+"""Universal simulation entrypoints and engine registry for QuASIM.
+
+This module exposes a stable ``run_scenario`` API used by the QNX substrate to
+route requests to different engines (modern, legacy, QVR, or future adapters).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, MutableMapping, Optional
+
+from quantum.python.quasim_sim import simulate as quasim_simulate
+
+from .scenarios import ScenarioSpec, build_circuit
+
+
+@dataclass
+class ScenarioResult:
+    """Structured result returned by :func:`run_scenario`."""
+
+    scenario_id: str
+    timesteps: int
+    seed: int
+    engine: str
+    raw_output: Dict[str, Any]
+
+    @property
+    def simulation_hash(self) -> str:
+        """Deterministic SHA-256 hash of ``raw_output``."""
+
+        data = json.dumps(self.raw_output, sort_keys=True, default=str).encode()
+        return hashlib.sha256(data).hexdigest()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "timesteps": self.timesteps,
+            "seed": self.seed,
+            "engine": self.engine,
+            "simulation_hash": self.simulation_hash,
+            "raw_output": self.raw_output,
+        }
+
+
+_ENGINE_REGISTRY: Dict[str, Callable[..., MutableMapping[str, Any]]] = {}
+
+
+def register_engine(name: str, fn: Callable[..., MutableMapping[str, Any]]) -> None:
+    """Register an engine function for :func:`run_scenario`."""
+
+    _ENGINE_REGISTRY[name] = fn
+
+
+def _run_modern_engine(
+    *, scenario_id: str, timesteps: int, seed: int, extra: Optional[Dict[str, Any]]
+) -> MutableMapping[str, Any]:
+    spec = ScenarioSpec(scenario_id=scenario_id, timesteps=timesteps, seed=seed, extra=extra or {})
+    circuit = build_circuit(spec)
+    result = quasim_simulate(circuit, precision="fp8")
+    return {
+        "engine": "quasim_modern",
+        "scenario_id": scenario_id,
+        "timesteps": timesteps,
+        "seed": seed,
+        "precision": "fp8",
+        "circuit_summary": {"num_gates": len(circuit), "gate_size": len(circuit[0]) if circuit else 0},
+        "result": [complex(value) for value in result],
+    }
+
+
+def run_scenario(
+    scenario_id: str,
+    timesteps: int,
+    seed: int,
+    engine: str = "quasim_modern",
+    extra: Optional[Dict[str, Any]] = None,
+) -> ScenarioResult:
+    """Execute a simulation scenario via a registered engine."""
+
+    if engine not in _ENGINE_REGISTRY:
+        raise ValueError(
+            f"Engine '{engine}' is not registered. Available engines: {list(_ENGINE_REGISTRY.keys())}"
+        )
+
+    backend_fn = _ENGINE_REGISTRY[engine]
+    raw_output = backend_fn(
+        scenario_id=scenario_id,
+        timesteps=timesteps,
+        seed=seed,
+        extra=extra or {},
+    )
+
+    return ScenarioResult(
+        scenario_id=scenario_id,
+        timesteps=timesteps,
+        seed=seed,
+        engine=engine,
+        raw_output=raw_output,
+    )
+
+
+register_engine("quasim_modern", _run_modern_engine)
+
+__all__ = ["ScenarioResult", "register_engine", "run_scenario", "build_circuit", "ScenarioSpec"]

--- a/quasim/universal_api.py
+++ b/quasim/universal_api.py
@@ -1,0 +1,234 @@
+"""Universal QuASIM Simulation API Layer.
+
+This module defines a single stable, forward-compatible entrypoint
+`run_scenario()` that QNX can call to execute a simulation across any
+internal QuASIM engine (modern, legacy, experimental, or external wrappers).
+
+The contract is intentionally minimal and stable:
+    - Inputs: scenario_id, timesteps, seed
+    - Output: structured dict with deterministic fields
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import random
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, MutableMapping, Optional
+
+from runtime.python.quasim.runtime import Config as RuntimeConfig, runtime as runtime_context
+
+
+# ---------------------------------------------------------------------------
+# Dataclass for internal standardized return payload
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ScenarioResult:
+    scenario_id: str
+    timesteps: int
+    seed: int
+    engine: str
+    raw_output: Dict[str, Any]
+
+    @property
+    def simulation_hash(self) -> str:
+        """Deterministic SHA-256 hash of raw_output."""
+        data = json.dumps(self.raw_output, sort_keys=True, default=str).encode()
+        return hashlib.sha256(data).hexdigest()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "timesteps": self.timesteps,
+            "seed": self.seed,
+            "engine": self.engine,
+            "simulation_hash": self.simulation_hash,
+            "raw_output": self.raw_output,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Loader registry — backend adapters drop into this dictionary
+# QNX backends call this same API.
+# ---------------------------------------------------------------------------
+
+_ENGINE_REGISTRY: Dict[str, Callable[..., MutableMapping[str, Any]]] = {}
+
+
+def register_engine(name: str, fn: Callable[..., MutableMapping[str, Any]]):
+    """Register a backend engine function."""
+    _ENGINE_REGISTRY[name] = fn
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _complex_to_json(value: complex) -> Dict[str, float]:
+    return {"real": float(value.real), "imag": float(value.imag)}
+
+
+def _generate_tensors(seed: int, timesteps: int) -> list[list[complex]]:
+    rng = random.Random(seed)
+    tensors: list[list[complex]] = []
+    for step in range(max(1, timesteps)):
+        base = float(step + 1)
+        tensors.append(
+            [
+                complex(base + rng.random(), rng.random()),
+                complex(base / 2 + rng.random(), rng.random() / 2),
+            ]
+        )
+    return tensors
+
+
+# ---------------------------------------------------------------------------
+# Backend implementations
+# ---------------------------------------------------------------------------
+
+
+def _run_modern_backend(
+    *, scenario_id: str, timesteps: int, seed: int, extra: Optional[Dict[str, Any]]
+) -> MutableMapping[str, Any]:
+    tensors = _generate_tensors(seed, timesteps)
+    with runtime_context(RuntimeConfig()) as handle:
+        outputs = handle.simulate(tensors)
+        latency = handle.average_latency
+
+    return {
+        "status": "ok",
+        "scenario_id": scenario_id,
+        "timesteps": timesteps,
+        "seed": seed,
+        "engine": "quasim_modern",
+        "average_latency": latency,
+        "outputs": [_complex_to_json(value) for value in outputs],
+        "metadata": extra or {},
+    }
+
+
+def _run_legacy_backend(
+    *, scenario_id: str, timesteps: int, seed: int, extra: Optional[Dict[str, Any]]
+) -> MutableMapping[str, Any]:
+    # Legacy mode reuses the same runtime but applies a deterministic postprocess
+    tensors = _generate_tensors(seed, timesteps)
+    with runtime_context(RuntimeConfig(simulation_precision="fp16")) as handle:
+        outputs = handle.simulate(tensors)
+        latency = handle.average_latency
+
+    adjusted = [complex(val.real * 0.95, val.imag * 0.95) for val in outputs]
+
+    return {
+        "status": "ok",
+        "scenario_id": scenario_id,
+        "timesteps": timesteps,
+        "seed": seed,
+        "engine": "quasim_legacy_v1_2_0",
+        "average_latency": latency,
+        "outputs": [_complex_to_json(value) for value in adjusted],
+        "metadata": {"mode": "legacy_v1_2_0", **(extra or {})},
+    }
+
+
+def _run_qvr_backend(
+    *, scenario_id: str, timesteps: int, seed: int, extra: Optional[Dict[str, Any]]
+) -> MutableMapping[str, Any]:
+    if os.name != "nt":  # pragma: no cover - platform-specific
+        raise RuntimeError("QVR backend requires Windows")
+
+    executable = os.environ.get("QVR_EXECUTABLE", "qvr.exe")
+    if not Path(executable).exists():
+        raise FileNotFoundError(f"QVR executable not found at '{executable}'")
+
+    payload = {"scenario_id": scenario_id, "timesteps": timesteps, "seed": seed}
+    if extra:
+        payload.update(extra)
+
+    process = subprocess.run(
+        [executable],
+        input=json.dumps(payload).encode(),
+        capture_output=True,
+        check=False,
+    )
+
+    stdout = process.stdout.decode(errors="replace")
+    stderr = process.stderr.decode(errors="replace")
+
+    try:
+        result_payload = json.loads(stdout) if stdout else {}
+    except json.JSONDecodeError:
+        result_payload = {"raw_stdout": stdout}
+
+    return {
+        "status": "ok" if process.returncode == 0 else "error",
+        "scenario_id": scenario_id,
+        "timesteps": timesteps,
+        "seed": seed,
+        "engine": "qvr_win",
+        "stdout": stdout,
+        "stderr": stderr,
+        "payload": result_payload,
+        "returncode": process.returncode,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Universal API entrypoint
+# ---------------------------------------------------------------------------
+
+
+def run_scenario(
+    scenario_id: str,
+    timesteps: int,
+    seed: int,
+    engine: str = "quasim_modern",
+    extra: Optional[Dict[str, Any]] = None,
+) -> ScenarioResult:
+    """
+    Execute a simulation scenario via a registered engine.
+
+    This function routes calls to the appropriate backend (modern, legacy,
+    QVR Windows interface, adapters, HPC wraps, etc.).
+    """
+    if engine not in _ENGINE_REGISTRY:
+        raise ValueError(
+            f"Engine '{engine}' is not registered. "
+            f"Available engines: {list(_ENGINE_REGISTRY.keys())}"
+        )
+
+    backend_fn = _ENGINE_REGISTRY[engine]
+    raw_output = backend_fn(
+        scenario_id=scenario_id,
+        timesteps=timesteps,
+        seed=seed,
+        extra=extra or {},
+    )
+
+    return ScenarioResult(
+        scenario_id=scenario_id,
+        timesteps=timesteps,
+        seed=seed,
+        engine=engine,
+        raw_output=raw_output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Register real backends
+# ---------------------------------------------------------------------------
+
+register_engine("quasim_modern", _run_modern_backend)
+register_engine("quasim_legacy_v1_2_0", _run_legacy_backend)
+register_engine("qvr_win", _run_qvr_backend)
+
+__all__ = [
+    "ScenarioResult",
+    "register_engine",
+    "run_scenario",
+]

--- a/tests/qnx/test_qnx_integration.py
+++ b/tests/qnx/test_qnx_integration.py
@@ -1,0 +1,34 @@
+import pytest
+
+from qnx import QNXSubstrate, SimulationConfig
+
+
+def test_modern_backend_deterministic_hash():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="integration", timesteps=3, seed=11)
+
+    first = substrate.run_simulation(config)
+    second = substrate.run_simulation(config)
+
+    assert first.simulation_hash == second.simulation_hash
+
+
+def test_legacy_backend_stub_through_substrate():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(
+        scenario_id="legacy", timesteps=2, seed=1, backend="quasim_legacy_v1_2_0"
+    )
+
+    result = substrate.run_simulation(config)
+
+    assert result.backend == "quasim_legacy_v1_2_0"
+    assert result.raw_results["status"] == "not_implemented"
+
+
+@pytest.mark.skipif(False, reason="Always execute")
+def test_qvr_backend_unavailable_on_non_windows():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="smoke", timesteps=1, seed=0, backend="qvr_win")
+
+    with pytest.raises(RuntimeError):
+        substrate.run_simulation(config)

--- a/tests/qnx/test_qnx_smoke.py
+++ b/tests/qnx/test_qnx_smoke.py
@@ -1,0 +1,17 @@
+from qnx import QNXSubstrate, SimulationConfig
+
+
+def test_qnx_substrate_initialises():
+    substrate = QNXSubstrate()
+    assert substrate.backends
+
+
+def test_qnx_run_with_modern_backend():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="smoke", timesteps=2, seed=42)
+    result = substrate.run_simulation(config)
+
+    assert result.backend == "quasim_modern"
+    assert result.simulation_hash
+    assert "raw_results" in result.__dict__
+    assert result.raw_results.get("engine") == "quasim_modern"

--- a/tests/qnx/test_quasim_legacy_backend.py
+++ b/tests/qnx/test_quasim_legacy_backend.py
@@ -1,0 +1,12 @@
+from qnx.backends.quasim_legacy_v120 import QuasimLegacyV120Backend
+from qnx.types import SimulationConfig
+
+
+def test_legacy_backend_stub():
+    backend = QuasimLegacyV120Backend()
+    config = SimulationConfig(scenario_id="legacy", timesteps=2, seed=1)
+
+    result = backend.run(config)
+
+    assert result["engine"] == "quasim_legacy_v1_2_0"
+    assert result["status"] == "not_implemented"

--- a/tests/qnx/test_quasim_modern_backend.py
+++ b/tests/qnx/test_quasim_modern_backend.py
@@ -1,0 +1,14 @@
+from qnx.backends.quasim_modern import QuasimModernBackend
+from qnx.types import SimulationConfig
+
+
+def test_modern_backend_runs_and_returns_result():
+    backend = QuasimModernBackend()
+    config = SimulationConfig(scenario_id="smoke", timesteps=3, seed=123)
+
+    first = backend.run(config)
+    second = backend.run(config)
+
+    assert first["engine"] == "quasim_modern"
+    assert first["raw_output"]["result"]
+    assert first == second

--- a/tests/qnx/test_qvr_win_backend.py
+++ b/tests/qnx/test_qvr_win_backend.py
@@ -1,0 +1,36 @@
+import json
+import types
+
+import pytest
+
+from qnx.backends.qvr_win import QVRWinBackend
+from qnx.types import SimulationConfig
+
+
+def test_qvr_backend_raises_on_non_windows(monkeypatch):
+    monkeypatch.setenv("QVR_EXECUTABLE", "qvr.exe")
+    backend = QVRWinBackend()
+    config = SimulationConfig(scenario_id="smoke", timesteps=1, seed=0, backend="qvr_win")
+
+    with pytest.raises(RuntimeError):
+        backend.run(config)
+
+
+def test_qvr_backend_handles_process(monkeypatch):
+    class DummyCompletedProcess(types.SimpleNamespace):
+        pass
+
+    def _fake_run(cmd, input, capture_output, check):
+        return DummyCompletedProcess(stdout=json.dumps({"ok": True}).encode(), stderr=b"", returncode=0)
+
+    monkeypatch.setattr("qnx.backends.qvr_win.subprocess.run", _fake_run)
+    monkeypatch.setattr("qnx.backends.qvr_win._is_windows", lambda: True)
+    monkeypatch.setattr("qnx.backends.qvr_win.Path.exists", lambda self: True)
+    monkeypatch.setenv("QVR_EXECUTABLE", "qvr.exe")
+    backend = QVRWinBackend()
+
+    config = SimulationConfig(scenario_id="smoke", timesteps=1, seed=0, backend="qvr_win")
+    result = backend.run(config)
+
+    assert result["engine"] == "qvr_win"
+    assert result["payload"] == {"ok": True}


### PR DESCRIPTION
## Summary
- add deterministic scenario builders and a universal simulation API that drives the modern QuASIM runtime
- wire QNX modern, legacy, and QVR backends through the substrate with updated hashing, result metadata, and packaging hooks
- expand QNX documentation, workflows, and tests covering the modern path, stubs, and Windows adapter behavior

## Testing
- python -m pytest tests/qnx -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a84b5afb4832b99fba4e6bcf32f65)