### PR TITLE
Add QNX lifecycle harness and validation report

### DIFF
--- a/.github/workflows/qnx-ci.yml
+++ b/.github/workflows/qnx-ci.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - "qnx/**"
       - "tests/qnx/**"
+      - "tests/qnx_integration/**"
+      - "docs/validation/qnx_backend_validation.md"
       - ".github/workflows/qnx-ci.yml"
   pull_request:
     paths:
       - "qnx/**"
       - "tests/qnx/**"
+      - "tests/qnx_integration/**"
+      - "docs/validation/qnx_backend_validation.md"
       - ".github/workflows/qnx-ci.yml"
 
 jobs:
@@ -28,6 +32,10 @@ jobs:
           pip install -e .
           pip install pytest
 
-      - name: Run QNX smoke tests
+      - name: Static interface check
         run: |
-          pytest tests/qnx/ -v
+          python -m compileall qnx tests/qnx tests/qnx_integration
+
+      - name: Run QNX integration harness
+        run: |
+          pytest tests/qnx tests/qnx_integration -v

--- a/docs/validation/qnx_backend_validation.md
+++ b/docs/validation/qnx_backend_validation.md
@@ -1,0 +1,49 @@
+# QNX backend validation report
+
+## Interface discovery
+
+* **Entrypoints**
+  * `qnx.core.QNXSubstrate` lifecycle hooks: `initialise_runtime()`, `boot_backend()`, `dispatch()`, `teardown_backend()`, and `lifecycle_run()` orchestrate init → boot → dispatch → teardown across backends.
+  * CLI: `python -m qnx.cli simulate --scenario <id>` (see `qnx/cli.py`).
+  * Universal contract: `quasim.api.simulate.run_scenario()` dispatches QuASIM engines consumed by `QuasimModernBackend`.
+* **Backends**
+  * `QuasimModernBackend` → calls `run_scenario()` via `ScenarioSpec` (current engine).
+  * `QuasimLegacyV120Backend` → stubbed shim returning `not_implemented` for legacy engine wiring.
+  * `QVRWinBackend` → Windows-only bridge to external QVR CLI (validated via environment probe).
+* **Lifecycle & IPC hooks**
+  * Lifecycle instrumentation lives in `QNXSubstrate` with optional RTOS hooks and integrity hashing in `qnx/security.py`.
+  * Mock RTOS provided for tests (`tests/qnx_integration/mock_qnx_rtos.py`) exercises boot, scheduler ticks, IPC bus, and teardown flows.
+* **Contracts & data structures**
+  * `SimulationConfig`, `SubstrateResult`, and `SecurityLevel` in `qnx/types.py` define runtime configuration and outputs.
+  * Deterministic hashing and validation live in `qnx/security.py`; sustainability metrics in `qnx/sustainability.py`.
+
+## Interface compliance and gaps
+
+* **Compliant**
+  * Modern backend executes QuASIM scenarios deterministically and returns normalized payloads.
+  * Lifecycle hooks exposed for init → boot → dispatch → teardown and IPC logging.
+  * CLI exercises substrate without hardware dependencies.
+* **Known gaps**
+  * Legacy backend remains a stub (`status: not_implemented`).
+  * `QVRWinBackend` is disabled on non-Windows platforms and relies on an external `qvr.exe` binary.
+  * Security validation currently performs placeholder checks only; enforcement hooks remain TODO.
+
+## Test harness summary
+
+* **Unit coverage**
+  * Public QNX module functions: CLI surface, backends, hashing/integrity helpers, sustainability fallback, and lifecycle orchestration.
+* **Integration coverage**
+  * Lifecycle flow over mock RTOS with IPC bus assertions.
+  * Deterministic QuASIM scenario execution and hash repeatability via substrate dispatch.
+  * Windows backend simulated with monkeypatched process execution.
+* **Location**: `tests/qnx/` (backend adapters) and `tests/qnx_integration/` (lifecycle, RTOS, CLI, contracts).
+
+## Validation results
+
+* Latest run: `pytest tests/qnx tests/qnx_integration -v` → 18 tests passed headlessly with deterministic mock RTOS coverage.
+
+## Recommendations
+
+* Implement the real legacy v1.2.0 adapter or deprecate the backend stub.
+* Add hardened security-context enforcement (policy checks, capability gating).
+* Provide a Windows CI lane to exercise `QVRWinBackend` end-to-end when infrastructure is available.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/qnx_integration/mock_qnx_rtos.py
+++ b/tests/qnx_integration/mock_qnx_rtos.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, List, MutableSequence
+
+
+@dataclass
+class SchedulerEvent:
+    tick: int
+    payload: Any
+
+
+class MockQNXRTOS:
+    """Lightweight RTOS stub to exercise lifecycle hooks without hardware."""
+
+    def __init__(self) -> None:
+        self.booted: bool = False
+        self.tick_count: int = 0
+        self.ipc_bus: MutableSequence[dict[str, Any]] = []
+        self.scheduler_log: List[SchedulerEvent] = []
+
+    def boot(self) -> dict[str, Any]:
+        self.booted = True
+        self.scheduler_log.append(SchedulerEvent(self.tick_count, "boot"))
+        return {"status": "booted", "ticks": self.tick_count}
+
+    def dispatch_ticks(self, *, iterations: int = 1, handler: Callable[[int], Any] | None = None) -> list[Any]:
+        outputs: list[Any] = []
+        for _ in range(iterations):
+            self.tick_count += 1
+            payload = handler(self.tick_count) if handler else {"tick": self.tick_count}
+            self.scheduler_log.append(SchedulerEvent(self.tick_count, payload))
+            outputs.append(payload)
+            time.sleep(0.001)
+        return outputs
+
+    def send_ipc(self, channel: str, payload: Any) -> dict[str, Any]:
+        message = {"channel": channel, "payload": payload, "tick": self.tick_count}
+        self.ipc_bus.append(message)
+        return message
+
+    def teardown(self) -> dict[str, Any]:
+        self.booted = False
+        return {"status": "stopped", "ticks": self.tick_count, "messages": len(self.ipc_bus)}
+
+
+__all__ = ["MockQNXRTOS", "SchedulerEvent"]

--- a/tests/qnx_integration/test_qnx_cli.py
+++ b/tests/qnx_integration/test_qnx_cli.py
@@ -1,0 +1,14 @@
+import json
+
+from qnx import cli
+
+
+def test_cli_simulate_produces_structured_output(capsys):
+    exit_code = cli.cli(["simulate", "--scenario", "cli-smoke", "--timesteps", "1"])
+
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+
+    assert exit_code == 0
+    assert set(payload) >= {"backend", "hash", "execution_time_ms"}
+    assert payload["backend"] == "quasim_modern"

--- a/tests/qnx_integration/test_qnx_lifecycle.py
+++ b/tests/qnx_integration/test_qnx_lifecycle.py
@@ -1,0 +1,29 @@
+from qnx import QNXSubstrate, SimulationConfig
+
+from tests.qnx_integration.mock_qnx_rtos import MockQNXRTOS
+
+
+def test_lifecycle_flow_with_mock_rtos():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="lifecycle", timesteps=2, seed=7)
+    mock_rtos = MockQNXRTOS()
+
+    lifecycle = substrate.lifecycle_run(config, rtos=mock_rtos)
+
+    assert lifecycle["init"]["status"] == "initialised"
+    assert lifecycle["boot"]["ready"] is True
+    assert lifecycle["dispatch_result"].simulation_hash
+    assert lifecycle["teardown"]["status"] == "stopped"
+    assert mock_rtos.ipc_bus[-1]["channel"] == "simulation_complete"
+
+
+def test_boot_state_fails_for_unavailable_backend():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="probe", timesteps=1, backend="quasim_modern")
+
+    boot_state = substrate.boot_backend(config.backend, config)
+
+    assert boot_state == {"backend": "quasim_modern", "ready": True}
+
+    teardown_state = substrate.teardown_backend(config.backend)
+    assert teardown_state["status"] == "stopped"

--- a/tests/qnx_integration/test_qnx_scenarios.py
+++ b/tests/qnx_integration/test_qnx_scenarios.py
@@ -1,0 +1,24 @@
+from qnx import QNXSubstrate, SimulationConfig
+
+
+def test_quasim_modern_scenario_contract():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="deterministic", timesteps=3, seed=1234)
+
+    result = substrate.run_simulation(config)
+
+    assert result.backend == "quasim_modern"
+    assert result.raw_results["scenario_id"] == "deterministic"
+    assert result.raw_results["raw_output"]["result"]
+    assert result.execution_time_ms >= 0
+
+
+def test_modern_engine_is_deterministic_when_reused():
+    substrate = QNXSubstrate()
+    config = SimulationConfig(scenario_id="repeatable", timesteps=1, seed=5)
+
+    first = substrate.run_simulation(config)
+    second = substrate.dispatch(config)
+
+    assert first.simulation_hash == second.simulation_hash
+    assert first.raw_results["raw_output"]["result"] == second.raw_results["raw_output"]["result"]

--- a/tests/qnx_integration/test_qnx_security_and_contracts.py
+++ b/tests/qnx_integration/test_qnx_security_and_contracts.py
@@ -1,0 +1,45 @@
+import json
+
+import pytest
+
+from qnx.security import compute_integrity_hash, validate_security_context, verify_integrity
+from qnx.sustainability import estimate_carbon
+from qnx.types import SecurityLevel, SubstrateResult
+
+
+def test_integrity_hash_round_trip():
+    payload = {"engine": "quasim_modern", "timesteps": 2}
+    digest = compute_integrity_hash(json.dumps(payload, sort_keys=True))
+
+    assert verify_integrity(json.dumps(payload, sort_keys=True), digest)
+    assert verify_integrity(json.dumps(payload, sort_keys=True), digest) is True
+
+
+def test_security_validation_accepts_all_levels():
+    for level in (SecurityLevel.LOW, SecurityLevel.MEDIUM, SecurityLevel.HIGH):
+        validate_security_context(level)
+
+
+def test_substrate_result_contract_roundtrip():
+    result = SubstrateResult(
+        backend="quasim_modern",
+        scenario_id="contract",
+        timesteps=2,
+        seed=1,
+        raw_results={"ok": True},
+        simulation_hash="hash",
+        execution_time_ms=1.2,
+        carbon_emissions_kg=0.0,
+        errors=[],
+        warnings=[],
+    )
+
+    assert result.raw_results["ok"] is True
+    assert result.seed == 1
+
+
+def test_carbon_estimation_gracefully_handles_missing_codecarbon(monkeypatch):
+    monkeypatch.setattr("qnx.sustainability.EmissionsTracker", None)
+    estimate = estimate_carbon({"sample": True})
+
+    assert estimate == 0.0


### PR DESCRIPTION
## Summary
- add lifecycle and dispatch hooks to the QNX substrate to support init, boot, dispatch, and teardown tracking
- build a mock QNX RTOS harness plus integration tests that exercise CLI, lifecycle, hashing, and deterministic scenario execution
- document QNX backend validation and expand CI to run static checks and the full QNX test suite

## Testing
- pytest tests/qnx tests/qnx_integration -v


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9446b390832ba73fdb5cd48919d7)