### PR TITLE
Add CLI for launching Q-Stack demo run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,11 @@ quasim-terc-obs = "quasim.cli.terc_obs_cli:cli"
 quasim-own = "quasim.cli.quasim_own:cli"
 qunimbus = "quasim.qunimbus.cli:main"
 qnx = "qnx.cli:cli"
+qstack = "qstack.launch:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["quasim*", "qnx*"]
+include = ["quasim*", "qnx*", "qstack*"]
 
 [tool.black]
 line-length = 100

--- a/qstack/README.md
+++ b/qstack/README.md
@@ -24,3 +24,12 @@ Q-Stack is a deterministic research playground that layers an identity root (Q),
 - `tests/`: deterministic unit and integration coverage for identity, runtime, cognition flows, simulation, valuation, and cross-layer integration.
 
 Import via `import qstack` or submodules (e.g., `from qstack.q import KeyManager`) to explore the building blocks. The code is self-contained and does not modify the rest of the QuASIM tree.
+
+## Launching a deterministic demo
+Run the lightweight CLI to spin up the identity, ledger, trust graph, and QNX runtime in one shot:
+
+```
+python -m qstack.launch --goal "stabilize" --energy 5
+```
+
+The command seeds an orchestrator identity, writes an attested ledger entry, constructs a trivial self-trust edge, and executes a single deterministic QNX VM cycle. The resulting JSON includes the orchestrator record, ledger head, trust relationships, runtime state, and execution trace so you can validate the stack wiring end-to-end.

--- a/qstack/launch.py
+++ b/qstack/launch.py
@@ -1,0 +1,103 @@
+"""CLI entrypoint to launch the deterministic Q-Stack demo run."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Dict
+
+import click
+
+from qstack.q.attestation import Attestor
+from qstack.q.identity import QIdentity
+from qstack.q.keys import KeyManager
+from qstack.q.ledger import Ledger
+from qstack.q.registry import IdentityRegistry
+from qstack.q.signing import Signer
+from qstack.q.trust_graph import TrustGraph
+from qstack.qnx.runtime.operators import OperatorLibrary
+from qstack.qnx.runtime.safety import RateLimiter, SafetyConstraints, SafetyEnvelope, SafetyValidator
+from qstack.qnx.runtime.scheduler import DeterministicScheduler
+from qstack.qnx.runtime.state import QNXState
+from qstack.qnx.runtime.tracing import TraceRecorder
+from qstack.qnx.runtime.vm import QNXVM
+
+
+def build_identity(seed: str) -> tuple[QIdentity, IdentityRegistry, TrustGraph]:
+    key_manager = KeyManager(seed)
+    signer = Signer(key_manager.derive_key("signing"))
+    attestor = Attestor(signer)
+    ledger = Ledger()
+    registry = IdentityRegistry(attestor=attestor, ledger=ledger)
+
+    orchestrator = QIdentity(name="orchestrator", key=key_manager.derive_key("orchestrator"))
+    registry.register(orchestrator, {"role": "orchestrator"})
+
+    trust_graph = TrustGraph()
+    trust_graph.add_trust(orchestrator, orchestrator)
+    return orchestrator, registry, trust_graph
+
+
+def build_runtime(state: QNXState) -> tuple[QNXVM, TraceRecorder]:
+    operators = OperatorLibrary()
+
+    def bind_goal(current_state: QNXState, goal: str) -> Dict[str, str]:
+        current_state.update("goal", goal)
+        return {"bound_goal": goal}
+
+    def advance_tick(current_state: QNXState, _goal: str) -> Dict[str, int]:
+        tick = current_state.read("tick", 0) + 1
+        current_state.update("tick", tick)
+        return {"tick": tick}
+
+    def manage_energy(current_state: QNXState, _goal: str) -> Dict[str, int]:
+        energy = max(current_state.read("energy", 0) - 1, 0)
+        current_state.update("energy", energy)
+        return {"energy": energy}
+
+    operators.register("bind_goal", bind_goal, description="Store the requested goal in state.")
+    operators.register("advance_tick", advance_tick, description="Move the deterministic clock forward.")
+    operators.register("energy_budget", manage_energy, description="Consume a single energy unit per cycle.")
+
+    constraints = SafetyConstraints(
+        [
+            lambda s, goal: isinstance(goal, str) and len(goal) > 0,
+            lambda s, _goal: s.read("energy", 0) >= 0,
+        ]
+    )
+    envelope = SafetyEnvelope({"energy": (0, 100), "tick": (0, 1000)})
+    rate_limiter = RateLimiter("qstack_invocations", max_calls=64)
+    safety = SafetyValidator(constraints, envelope, rate_limiter)
+
+    tracer = TraceRecorder()
+    scheduler = DeterministicScheduler(operators)
+    vm = QNXVM(scheduler=scheduler, safety=safety, tracer=tracer)
+    return vm, tracer
+
+
+@click.command()
+@click.option("--seed", default="qstack-root-seed", show_default=True, help="Deterministic seed for identity derivation.")
+@click.option("--goal", default="stabilize", show_default=True, help="Goal string to bind into the runtime state.")
+@click.option("--energy", default=5, show_default=True, type=int, help="Starting energy budget for the runtime.")
+def main(seed: str, goal: str, energy: int) -> None:
+    orchestrator, registry, trust_graph = build_identity(seed)
+    state = QNXState({"energy": energy, "tick": 0})
+
+    vm, tracer = build_runtime(state)
+    execution = vm.run_cycle(state, goal)
+
+    output = {
+        "orchestrator": orchestrator.to_dict(),
+        "ledger_head": asdict(registry.ledger.head()) if registry.ledger.head() else None,
+        "trust": {
+            "trusted": sorted(trust_graph.trusted(orchestrator)),
+            "self_reachable": trust_graph.verify_path(orchestrator, orchestrator),
+        },
+        "runtime_state": state.data,
+        "execution": execution,
+    }
+
+    click.echo(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a qstack launch CLI that seeds an orchestrator, ledger, trust graph, and executes a deterministic QNX cycle
- expose the CLI via project scripts and include qstack packages in discovery
- document the launch command in the Q-Stack README

## Testing
- python -m qstack.launch --goal "stabilize" --energy 3


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920fab44c88832b84a1da00d2978889)