### PR TITLE
feat: integrate verified FLT exponent reduction into QRATUM

### DIFF
--- a/.github/workflows/qratum-flt.yml
+++ b/.github/workflows/qratum-flt.yml
@@ -1,0 +1,36 @@
+name: QRATUM-FLT
+
+on:
+  push:
+    paths:
+      - "qratum/mathematics/flt/**"
+      - ".github/workflows/qratum-flt.yml"
+  pull_request:
+    paths:
+      - "qratum/mathematics/flt/**"
+      - ".github/workflows/qratum-flt.yml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: qratum/mathematics/flt
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Restore Lake cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            qratum/mathematics/flt/.lake
+          key: qratum-flt-${{ runner.os }}-${{ hashFiles('qratum/mathematics/flt/lakefile.lean', 'qratum/mathematics/flt/lean-toolchain') }}
+      - name: Resolve dependencies
+        run: lake update
+      - name: Build Lean library
+        run: lake build
+      - name: Reject proof placeholders
+        run: python scripts/audit_placeholders.py

--- a/qratum/mathematics/flt/README.md
+++ b/qratum/mathematics/flt/README.md
@@ -1,0 +1,53 @@
+# QRATUM-FLT
+
+QRATUM-FLT is a formal-verification program for reconstructing and auditing the
+modern proof of Fermat's Last Theorem (FLT). It does **not** claim to rediscover
+or replace the theorem proved by Andrew Wiles and Richard Taylor.
+
+## Current milestone: M0 — exponent reduction
+
+Formal target:
+
+> If FLT holds for exponent 4 and for every odd prime exponent, then FLT holds
+> for every natural exponent greater than 2.
+
+The reduction is elementary but foundational:
+
+1. If an exponent `n > 2` has an odd prime divisor `p`, a solution at exponent
+   `n = p * m` induces a solution at exponent `p` by replacing `(x,y,z)` with
+   `(x^m,y^m,z^m)`.
+2. If `n` has no odd prime divisor, then `n` is a power of two; because `n > 2`,
+   it is divisible by 4, and a solution at exponent `n = 4 * m` induces a
+   solution at exponent 4.
+
+## Trust boundary
+
+A milestone is accepted only when all of the following hold:
+
+- Lean compiles the target theorem.
+- No `sorry`, `admit`, or hidden placeholder remains.
+- Any imported mathematical result is stated explicitly as a hypothesis or
+  traced to a verified dependency.
+- The build is reproducible from pinned toolchain and dependency versions.
+
+## Layout
+
+- `lean/QRATUM/FLT/Basic.lean`: definitions and exponent-lifting lemma.
+- `lean/QRATUM/FLT/Reduction.lean`: M0 theorem interface and reduction proof.
+- `blueprint/dependency_graph.json`: machine-readable proof graph.
+- `scripts/audit_placeholders.py`: rejects common Lean proof placeholders.
+
+## Build
+
+From this directory:
+
+```bash
+lake update
+lake build
+python scripts/audit_placeholders.py
+```
+
+## Honest status
+
+The source scaffold and audit tooling are present. Until CI or a local Lean
+installation runs `lake build`, compilation is **not yet certified**.

--- a/qratum/mathematics/flt/README.md
+++ b/qratum/mathematics/flt/README.md
@@ -1,47 +1,60 @@
 # QRATUM-FLT
 
-QRATUM-FLT is a formal-verification program for reconstructing and auditing the
-modern proof of Fermat's Last Theorem (FLT). It does **not** claim to rediscover
-or replace the theorem proved by Andrew Wiles and Richard Taylor.
+QRATUM-FLT is a formal-verification and proof-audit program for Fermat's Last
+Theorem (FLT). It does **not** claim to rediscover the theorem proved by Andrew
+Wiles and Richard Taylor.
 
-## Current milestone: M0 — exponent reduction
+## Milestone M0 — exponent reduction
 
-Formal target:
+M0 establishes:
 
-> If FLT holds for exponent 4 and for every odd prime exponent, then FLT holds
-> for every natural exponent greater than 2.
+> If FLT holds for every odd prime exponent, then FLT holds for every natural
+> exponent greater than two.
 
-The reduction is elementary but foundational:
+The live Mathlib dependency already contains kernel-checked proofs of:
 
-1. If an exponent `n > 2` has an odd prime divisor `p`, a solution at exponent
-   `n = p * m` induces a solution at exponent `p` by replacing `(x,y,z)` with
-   `(x^m,y^m,z^m)`.
-2. If `n` has no odd prime divisor, then `n` is a power of two; because `n > 2`,
-   it is divisible by 4, and a solution at exponent `n = 4 * m` induces a
-   solution at exponent 4.
+- `FermatLastTheoremWith.mono`: FLT at an exponent lifts to its multiples;
+- `Nat.four_dvd_or_exists_odd_prime_and_dvd_of_two_lt`: every exponent above
+  two is divisible by four or has an odd prime divisor;
+- `fermatLastTheoremFour`: the exponent-four case by infinite descent;
+- `FermatLastTheorem.of_odd_primes`: the complete M0 reduction.
+
+QRATUM therefore integrates and audits these canonical results instead of
+maintaining a duplicate provisional proof.
+
+## Current frontier
+
+After M0, the unresolved formalization target is the odd-prime theorem family:
+
+```lean
+∀ p : ℕ, Nat.Prime p → Odd p → FermatLastTheoremFor p
+```
+
+Completing that target requires the deep Frey–Ribet–Taylor–Wiles chain or a
+verified equivalent. QRATUM must treat every imported result and remaining gap
+as an explicit dependency.
 
 ## Trust boundary
 
-A milestone is accepted only when all of the following hold:
+A QRATUM milestone is accepted only when:
 
-- Lean compiles the target theorem.
-- No `sorry`, `admit`, or hidden placeholder remains.
-- Any imported mathematical result is stated explicitly as a hypothesis or
-  traced to a verified dependency.
-- The build is reproducible from pinned toolchain and dependency versions.
+- Lean compiles the target theorem;
+- no `sorry`, `admit`, local axiom, or unsafe theorem remains;
+- imported results are pinned and traced to their source modules;
+- a clean build reproduces from the pinned toolchain and dependency revision.
 
 ## Layout
 
-- `lean/QRATUM/FLT/Basic.lean`: definitions and exponent-lifting lemma.
-- `lean/QRATUM/FLT/Reduction.lean`: M0 theorem interface and reduction proof.
+- `lean/QRATUM/FLT/Basic.lean`: aliases and audited wrappers around Mathlib's
+  canonical FLT API.
+- `lean/QRATUM/FLT/Reduction.lean`: M0 integration.
 - `blueprint/dependency_graph.json`: machine-readable proof graph.
-- `scripts/audit_placeholders.py`: rejects common Lean proof placeholders.
+- `scripts/audit_placeholders.py`: placeholder and local-axiom rejection.
 
 ## Build
 
-From this directory:
-
 ```bash
+cd qratum/mathematics/flt
 lake update
 lake build
 python scripts/audit_placeholders.py
@@ -49,5 +62,7 @@ python scripts/audit_placeholders.py
 
 ## Honest status
 
-The source scaffold and audit tooling are present. Until CI or a local Lean
-installation runs `lake build`, compilation is **not yet certified**.
+The mathematical content of M0 exists in Mathlib and is now wired into QRATUM.
+QRATUM's own wrapper package remains **build-pending** until its dedicated CI
+job completes successfully. The full FLT proof is not complete because the
+odd-prime theorem family remains the central deep dependency.

--- a/qratum/mathematics/flt/blueprint/dependency_graph.json
+++ b/qratum/mathematics/flt/blueprint/dependency_graph.json
@@ -1,0 +1,65 @@
+{
+  "program": "QRATUM-FLT",
+  "milestone": "M0",
+  "claim": "FLT for exponent 4 plus all odd prime exponents implies FLT for every exponent greater than 2",
+  "status": "scaffolded_not_yet_ci_verified",
+  "nodes": [
+    {
+      "id": "FLT-DEF-001",
+      "kind": "definition",
+      "name": "FermatAt",
+      "path": "lean/QRATUM/FLT/Basic.lean",
+      "status": "implemented",
+      "dependencies": []
+    },
+    {
+      "id": "FLT-LIFT-001",
+      "kind": "theorem",
+      "name": "fermatAt_of_dvd",
+      "path": "lean/QRATUM/FLT/Basic.lean",
+      "status": "implemented_unverified",
+      "dependencies": ["FLT-DEF-001"]
+    },
+    {
+      "id": "FLT-COVER-001",
+      "kind": "theorem_target",
+      "name": "ExponentCoverage",
+      "path": "lean/QRATUM/FLT/Reduction.lean",
+      "status": "specified_not_proved",
+      "dependencies": []
+    },
+    {
+      "id": "FLT-FOUR-001",
+      "kind": "deep_dependency",
+      "name": "FermatAt 4",
+      "status": "external_hypothesis",
+      "dependencies": []
+    },
+    {
+      "id": "FLT-ODD-PRIME-001",
+      "kind": "deep_dependency",
+      "name": "FermatAt p for every odd prime p",
+      "status": "external_hypothesis",
+      "dependencies": []
+    },
+    {
+      "id": "FLT-M0-ASSEMBLY",
+      "kind": "theorem",
+      "name": "flt_of_four_and_odd_primes",
+      "path": "lean/QRATUM/FLT/Reduction.lean",
+      "status": "implemented_unverified",
+      "dependencies": [
+        "FLT-LIFT-001",
+        "FLT-COVER-001",
+        "FLT-FOUR-001",
+        "FLT-ODD-PRIME-001"
+      ]
+    }
+  ],
+  "acceptance": {
+    "lake_build": false,
+    "placeholder_audit": false,
+    "clean_rebuild": false,
+    "m0_complete": false
+  }
+}

--- a/qratum/mathematics/flt/blueprint/dependency_graph.json
+++ b/qratum/mathematics/flt/blueprint/dependency_graph.json
@@ -1,65 +1,73 @@
 {
   "program": "QRATUM-FLT",
   "milestone": "M0",
-  "claim": "FLT for exponent 4 plus all odd prime exponents implies FLT for every exponent greater than 2",
-  "status": "scaffolded_not_yet_ci_verified",
+  "claim": "FLT for all odd prime exponents implies FLT for every exponent greater than 2",
+  "status": "canonical_mathlib_proof_integrated_build_pending",
   "nodes": [
     {
-      "id": "FLT-DEF-001",
-      "kind": "definition",
-      "name": "FermatAt",
-      "path": "lean/QRATUM/FLT/Basic.lean",
-      "status": "implemented",
+      "id": "MATHLIB-FLT-BASIC",
+      "kind": "verified_dependency",
+      "name": "FermatLastTheoremFor and FermatLastTheoremWith.mono",
+      "module": "Mathlib.NumberTheory.FLT.Basic",
+      "status": "upstream_kernel_checked",
       "dependencies": []
     },
     {
-      "id": "FLT-LIFT-001",
-      "kind": "theorem",
-      "name": "fermatAt_of_dvd",
-      "path": "lean/QRATUM/FLT/Basic.lean",
-      "status": "implemented_unverified",
-      "dependencies": ["FLT-DEF-001"]
-    },
-    {
-      "id": "FLT-COVER-001",
-      "kind": "theorem_target",
-      "name": "ExponentCoverage",
-      "path": "lean/QRATUM/FLT/Reduction.lean",
-      "status": "specified_not_proved",
+      "id": "MATHLIB-FLT-COVERAGE",
+      "kind": "verified_dependency",
+      "name": "Nat.four_dvd_or_exists_odd_prime_and_dvd_of_two_lt",
+      "module": "Mathlib.NumberTheory.FLT.Four",
+      "status": "upstream_kernel_checked",
       "dependencies": []
     },
     {
-      "id": "FLT-FOUR-001",
-      "kind": "deep_dependency",
-      "name": "FermatAt 4",
-      "status": "external_hypothesis",
-      "dependencies": []
+      "id": "MATHLIB-FLT-FOUR",
+      "kind": "verified_dependency",
+      "name": "fermatLastTheoremFour",
+      "module": "Mathlib.NumberTheory.FLT.Four",
+      "status": "upstream_kernel_checked",
+      "dependencies": ["MATHLIB-FLT-BASIC"]
     },
     {
-      "id": "FLT-ODD-PRIME-001",
-      "kind": "deep_dependency",
-      "name": "FermatAt p for every odd prime p",
-      "status": "external_hypothesis",
-      "dependencies": []
-    },
-    {
-      "id": "FLT-M0-ASSEMBLY",
-      "kind": "theorem",
-      "name": "flt_of_four_and_odd_primes",
-      "path": "lean/QRATUM/FLT/Reduction.lean",
-      "status": "implemented_unverified",
+      "id": "MATHLIB-FLT-M0",
+      "kind": "verified_dependency",
+      "name": "FermatLastTheorem.of_odd_primes",
+      "module": "Mathlib.NumberTheory.FLT.Four",
+      "status": "upstream_kernel_checked",
       "dependencies": [
-        "FLT-LIFT-001",
-        "FLT-COVER-001",
-        "FLT-FOUR-001",
-        "FLT-ODD-PRIME-001"
+        "MATHLIB-FLT-BASIC",
+        "MATHLIB-FLT-COVERAGE",
+        "MATHLIB-FLT-FOUR"
+      ]
+    },
+    {
+      "id": "QRATUM-FLT-M0-WRAPPER",
+      "kind": "integration_theorem",
+      "name": "QRATUM.FLT.flt_of_odd_primes",
+      "path": "lean/QRATUM/FLT/Reduction.lean",
+      "status": "implemented_build_pending",
+      "dependencies": ["MATHLIB-FLT-M0"]
+    },
+    {
+      "id": "FLT-ODD-PRIME-FRONTIER",
+      "kind": "open_formalization_frontier",
+      "name": "FLT for every odd prime exponent",
+      "status": "not_complete",
+      "dependencies": [
+        "Frey curve construction",
+        "Ribet level lowering",
+        "semistable modularity / Taylor-Wiles"
       ]
     }
   ],
   "acceptance": {
+    "upstream_m0_identified": true,
+    "upstream_exponent_four_identified": true,
+    "qratum_wrapper_implemented": true,
     "lake_build": false,
     "placeholder_audit": false,
     "clean_rebuild": false,
-    "m0_complete": false
+    "m0_integration_complete": false,
+    "full_flt_complete": false
   }
 }

--- a/qratum/mathematics/flt/lakefile.lean
+++ b/qratum/mathematics/flt/lakefile.lean
@@ -1,0 +1,12 @@
+import Lake
+open Lake DSL
+
+package «qratum-flt» where
+  moreLeanArgs := #["-DwarningAsError=true"]
+
+require mathlib from git
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.19.0"
+
+@[default_target]
+lean_lib QRATUM where
+  srcDir := "lean"

--- a/qratum/mathematics/flt/lean-toolchain
+++ b/qratum/mathematics/flt/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.19.0

--- a/qratum/mathematics/flt/lean/QRATUM.lean
+++ b/qratum/mathematics/flt/lean/QRATUM.lean
@@ -1,0 +1,2 @@
+import QRATUM.FLT.Basic
+import QRATUM.FLT.Reduction

--- a/qratum/mathematics/flt/lean/QRATUM/FLT/Basic.lean
+++ b/qratum/mathematics/flt/lean/QRATUM/FLT/Basic.lean
@@ -1,28 +1,16 @@
-import Mathlib
+import Mathlib.NumberTheory.FLT.Basic
 
 namespace QRATUM.FLT
 
-/-- Fermat's equation has no positive natural-number solution at exponent `n`. -/
-def FermatAt (n : ℕ) : Prop :=
-  ∀ x y z : ℕ, 0 < x → 0 < y → 0 < z → x ^ n + y ^ n ≠ z ^ n
+/-- QRATUM alias for Mathlib's canonical fixed-exponent FLT statement. -/
+abbrev FermatAt (n : ℕ) : Prop := _root_.FermatLastTheoremFor n
 
-/-- Full Fermat's Last Theorem over positive natural numbers. -/
-def FermatLastTheorem : Prop :=
-  ∀ n : ℕ, 2 < n → FermatAt n
+/-- QRATUM alias for Mathlib's canonical full FLT statement. -/
+abbrev Statement : Prop := _root_.FermatLastTheorem
 
-/-- A counterexample at exponent `n` descends to any positive divisor `d` of
-`n`, by replacing each base with its `n / d`-th power. Equivalently, FLT at
-`d` lifts to every positive multiple `n` of `d`. -/
-theorem fermatAt_of_dvd
-    {d n : ℕ}
-    (hd : 0 < d)
-    (hn : 0 < n)
-    (hdn : d ∣ n)
-    (h : FermatAt d) : FermatAt n := by
-  rcases hdn with ⟨k, rfl⟩
-  have hk : 0 < k := by omega
-  intro x y z hx hy hz hxyz
-  apply h (x ^ k) (y ^ k) (z ^ k) (by positivity) (by positivity) (by positivity)
-  simpa [pow_mul, Nat.mul_comm] using hxyz
+/-- FLT at an exponent lifts to every multiple of that exponent. This theorem is
+not reproved locally; QRATUM exposes and audits Mathlib's kernel-checked result. -/
+theorem fermatAt_of_dvd {d n : ℕ} (hdn : d ∣ n) (h : FermatAt d) : FermatAt n :=
+  FermatLastTheoremFor.mono hdn h
 
 end QRATUM.FLT

--- a/qratum/mathematics/flt/lean/QRATUM/FLT/Basic.lean
+++ b/qratum/mathematics/flt/lean/QRATUM/FLT/Basic.lean
@@ -1,0 +1,28 @@
+import Mathlib
+
+namespace QRATUM.FLT
+
+/-- Fermat's equation has no positive natural-number solution at exponent `n`. -/
+def FermatAt (n : ℕ) : Prop :=
+  ∀ x y z : ℕ, 0 < x → 0 < y → 0 < z → x ^ n + y ^ n ≠ z ^ n
+
+/-- Full Fermat's Last Theorem over positive natural numbers. -/
+def FermatLastTheorem : Prop :=
+  ∀ n : ℕ, 2 < n → FermatAt n
+
+/-- A counterexample at exponent `n` descends to any positive divisor `d` of
+`n`, by replacing each base with its `n / d`-th power. Equivalently, FLT at
+`d` lifts to every positive multiple `n` of `d`. -/
+theorem fermatAt_of_dvd
+    {d n : ℕ}
+    (hd : 0 < d)
+    (hn : 0 < n)
+    (hdn : d ∣ n)
+    (h : FermatAt d) : FermatAt n := by
+  rcases hdn with ⟨k, rfl⟩
+  have hk : 0 < k := by omega
+  intro x y z hx hy hz hxyz
+  apply h (x ^ k) (y ^ k) (z ^ k) (by positivity) (by positivity) (by positivity)
+  simpa [pow_mul, Nat.mul_comm] using hxyz
+
+end QRATUM.FLT

--- a/qratum/mathematics/flt/lean/QRATUM/FLT/Reduction.lean
+++ b/qratum/mathematics/flt/lean/QRATUM/FLT/Reduction.lean
@@ -1,23 +1,22 @@
+import Mathlib.NumberTheory.FLT.Four
 import QRATUM.FLT.Basic
 
 namespace QRATUM.FLT
 
-/-- Arithmetic coverage needed by the M0 reduction: every exponent greater than
-2 is divisible by 4 or has an odd prime divisor. This is isolated so the
-number-theoretic decomposition can be proved and audited independently. -/
-def ExponentCoverage : Prop :=
-  ∀ n : ℕ, 2 < n → 4 ∣ n ∨ ∃ p : ℕ, Nat.Prime p ∧ Odd p ∧ p ∣ n
+/-- Every exponent greater than two is divisible by four or has an odd prime
+factor. QRATUM exposes Mathlib's proved arithmetic decomposition. -/
+theorem exponent_coverage {n : ℕ} (hn : 2 < n) :
+    4 ∣ n ∨ ∃ p : ℕ, Nat.Prime p ∧ p ∣ n ∧ Odd p :=
+  Nat.four_dvd_or_exists_odd_prime_and_dvd_of_two_lt hn
 
-/-- M0 assembly theorem. Given exponent coverage, FLT at exponent 4, and FLT
-at every odd prime exponent, FLT follows at every exponent greater than 2. -/
-theorem flt_of_four_and_odd_primes
-    (coverage : ExponentCoverage)
-    (hFour : FermatAt 4)
-    (hOddPrime : ∀ p : ℕ, Nat.Prime p → Odd p → FermatAt p) :
-    FermatLastTheorem := by
-  intro n hn
-  rcases coverage n hn with hFourDivides | ⟨p, hp, hOdd, hpDivides⟩
-  · exact fermatAt_of_dvd (by norm_num) (by omega) hFourDivides hFour
-  · exact fermatAt_of_dvd hp.pos (by omega) hpDivides (hOddPrime p hp hOdd)
+/-- The exponent-four case is already formalized in Mathlib by infinite descent. -/
+theorem exponent_four : FermatAt 4 :=
+  fermatLastTheoremFour
+
+/-- M0: proving FLT for odd prime exponents suffices for the full theorem.
+Mathlib supplies both the exponent-four case and the arithmetic reduction. -/
+theorem flt_of_odd_primes
+    (hOddPrime : ∀ p : ℕ, Nat.Prime p → Odd p → FermatAt p) : Statement :=
+  FermatLastTheorem.of_odd_primes hOddPrime
 
 end QRATUM.FLT

--- a/qratum/mathematics/flt/lean/QRATUM/FLT/Reduction.lean
+++ b/qratum/mathematics/flt/lean/QRATUM/FLT/Reduction.lean
@@ -1,0 +1,23 @@
+import QRATUM.FLT.Basic
+
+namespace QRATUM.FLT
+
+/-- Arithmetic coverage needed by the M0 reduction: every exponent greater than
+2 is divisible by 4 or has an odd prime divisor. This is isolated so the
+number-theoretic decomposition can be proved and audited independently. -/
+def ExponentCoverage : Prop :=
+  ∀ n : ℕ, 2 < n → 4 ∣ n ∨ ∃ p : ℕ, Nat.Prime p ∧ Odd p ∧ p ∣ n
+
+/-- M0 assembly theorem. Given exponent coverage, FLT at exponent 4, and FLT
+at every odd prime exponent, FLT follows at every exponent greater than 2. -/
+theorem flt_of_four_and_odd_primes
+    (coverage : ExponentCoverage)
+    (hFour : FermatAt 4)
+    (hOddPrime : ∀ p : ℕ, Nat.Prime p → Odd p → FermatAt p) :
+    FermatLastTheorem := by
+  intro n hn
+  rcases coverage n hn with hFourDivides | ⟨p, hp, hOdd, hpDivides⟩
+  · exact fermatAt_of_dvd (by norm_num) (by omega) hFourDivides hFour
+  · exact fermatAt_of_dvd hp.pos (by omega) hpDivides (hOddPrime p hp hOdd)
+
+end QRATUM.FLT

--- a/qratum/mathematics/flt/scripts/audit_placeholders.py
+++ b/qratum/mathematics/flt/scripts/audit_placeholders.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fail if Lean source contains common proof placeholders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1] / "lean"
+FORBIDDEN = {
+    "sorry": re.compile(r"\bsorry\b"),
+    "admit": re.compile(r"\badmit\b"),
+    "axiom": re.compile(r"^\s*axiom\b", re.MULTILINE),
+    "unsafe theorem": re.compile(r"\bunsafe\s+theorem\b"),
+}
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in sorted(ROOT.rglob("*.lean")):
+        text = path.read_text(encoding="utf-8")
+        for name, pattern in FORBIDDEN.items():
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                failures.append(f"{path.relative_to(ROOT)}:{line}: forbidden {name}")
+
+    if failures:
+        print("QRATUM-FLT placeholder audit FAILED", file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+
+    print("QRATUM-FLT placeholder audit PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Introduces QRATUM-FLT as a formal-verification and proof-audit subsystem, aligned with Mathlib's canonical FLT API.

### Included
- Standalone Lean 4 / Mathlib package with pinned toolchain.
- QRATUM aliases for `FermatLastTheoremFor` and `FermatLastTheorem`.
- Audited wrapper around `FermatLastTheoremWith.mono`.
- Integration of Mathlib's kernel-checked exponent-four theorem `fermatLastTheoremFour`.
- Integration of the exact M0 theorem `FermatLastTheorem.of_odd_primes`.
- Machine-readable dependency graph separating verified dependencies from the open odd-prime frontier.
- Placeholder/local-axiom audit script.
- Dedicated GitHub Actions workflow.

## Important correction

The exponent-four proof and full reduction from arbitrary exponents to odd-prime exponents are already formally proved in Mathlib. QRATUM now reuses and audits those results rather than maintaining a duplicate provisional implementation.

## Scientific status

M0 is mathematically available upstream and wired into QRATUM. The QRATUM wrapper build is still pending CI. The full theorem remains incomplete because the theorem family for all odd prime exponents—the Frey–Ribet–Taylor–Wiles frontier—is not yet fully formalized here.

## Acceptance gates
- [x] canonical fixed-exponent FLT API identified
- [x] exponent-four formal proof identified and integrated
- [x] odd-prime reduction theorem identified and integrated
- [x] QRATUM wrapper implemented without placeholders
- [ ] `lake update`
- [ ] `lake build`
- [ ] placeholder audit passes in CI
- [ ] clean reproducible rebuild
- [ ] odd-prime theorem family completed
